### PR TITLE
Update to babel-preset-env

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,5 @@
 // turn these back on progressively
 const todo = {
-  'react/no-unused-prop-types': [
-    // turn to error after this cleanup story is done
-    'warn'
-  ],
   'react/jsx-filename-extension': [
     // most disruptive with the file renames
     'off'
@@ -70,6 +66,10 @@ module.exports = {
           'allowForLoopAfterthoughts': true
         }
       ],
+      'react/no-unused-prop-types': [
+        // we want to capture prop types that aren't used
+        'error'
+      ],
       // May revise this when as we get more cleanup done
       'react/forbid-prop-types': [
         'off'
@@ -87,6 +87,8 @@ module.exports = {
       'no-useless-escape': [
         'off'
       ],
+      // these accessibility rules will be a detriment to existing code/styles,
+      // perhaps in the future
       'jsx-a11y/href-no-hash': [
         'off'
       ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,123 @@
+// turn these back on progressively
+const todo = {
+  'react/no-unused-prop-types': [
+    // turn to error after this cleanup story is done
+    'warn'
+  ],
+  'react/jsx-filename-extension': [
+    // most disruptive with the file renames
+    'off'
+  ],
+  'react/require-default-props': [
+    // very useful for future development and generating test/storybook mocks
+    'off'
+  ],
+  'react/prop-types': [
+    // useful for getting a clear indication of a component's signature
+    'off',
+    {
+      // shouldn't need to define children, also ineffective to use `PropTypes.node` as it still fails for stateless components
+      ignore: ['children']
+    }
+  ],
+  'comma-dangle': [
+    'off'
+  ],
+  'arrow-parens': [
+    'off'
+  ],
+  'indent': [
+    'off'
+  ],
+  'react/no-find-dom-node': [
+    // can use refs instead
+    'off',
+  ],
+};
+
+module.exports = {
+  'extends': 'airbnb',
+  'env': {
+    'jasmine': true
+  },
+  'rules': Object.assign({},
+    todo,
+    {
+      // turned off because the PHP side returns dangling properties which trigger this...
+      // could revise later and add exceptions for PHP data
+      'no-underscore-dangle': [
+        'off',
+        {
+          'allow': [
+            '_t'
+          ],
+          'allowAfterThis': true
+        }
+      ],
+      'no-unused-vars': [
+        'error',
+        {
+          'vars': 'local'
+        }
+      ],
+      // increased to error because it's strongly discouraged
+      'react/no-danger': [
+        'error'
+      ],
+      'no-plusplus': [
+        'error',
+        {
+          'allowForLoopAfterthoughts': true
+        }
+      ],
+      // May revise this when as we get more cleanup done
+      'react/forbid-prop-types': [
+        'off'
+      ],
+      'import/prefer-default-export': [
+        'off'
+      ],
+      'import/first': [
+        'off'
+      ],
+      'class-methods-use-this': [
+        'off'
+      ],
+      // this one makes no sense in some regex contexts
+      'no-useless-escape': [
+        'off'
+      ],
+      'jsx-a11y/href-no-hash': [
+        'off'
+      ],
+      'jsx-a11y/iframe-has-title': [
+        'off'
+      ],
+      'jsx-a11y/anchor-has-content': [
+        'off'
+      ],
+    }),
+  'settings': {
+    'import/extensions': [
+      '.js',
+      '.jsx'
+    ],
+    'import/resolver': {
+      'node': {
+        'extensions': [
+          '.js',
+          '.jsx'
+        ],
+        'moduleDirectory': [
+          '.',
+          'client/src',
+          '../silverstripe-admin/client/src',
+          '../silverstripe-admin/node_modules',
+          'silverstripe-admin/client/src',
+          'silverstripe-admin/node_modules',
+          'node_modules'
+        ]
+      }
+    }
+  }
+};

--- a/js/modules.js
+++ b/js/modules.js
@@ -30,8 +30,7 @@ module.exports = (ENV, { SRC, MODULES, THIRDPARTY }) => {
         loader: 'babel-loader',
         options: {
           presets: [
-            ['es2015', { modules: false }],
-            'es2016',
+            ['env', { modules: false }],
             'react',
           ],
           plugins: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@silverstripe/webpack-config",
-	"version": "0.2.9",
+	"version": "0.3.0",
 	"description": "SilverStripe config files for modules",
 	"engines": {
 		"node": ">= 6.x"

--- a/package.json
+++ b/package.json
@@ -32,16 +32,17 @@
 		"autoprefixer": "^6.4.0",
 		"babel-core": "^6.24.1",
 		"babel-loader": "^7.0.0",
-		"babel-plugin-transform-es2015-modules-umd": "^6.6.5",
-		"babel-plugin-transform-object-rest-spread": "^6.8.0",
-		"babel-preset-es2015": "^6.24.1",
-		"babel-preset-es2016": "^6.24.1",
+		"babel-plugin-transform-object-rest-spread": "^6.26.0",
+		"babel-preset-env": "^1.6.0",
 		"babel-preset-react": "^6.24.1",
 		"css-loader": "^0.28.1",
-		"eslint": "^2.5.3",
-		"eslint-config-airbnb": "^6.2.0",
+		"eslint": "^4.6.1",
+		"eslint-config-airbnb": "^15.1.0",
+		"eslint-config-airbnb-base": "^12.0.0",
 		"eslint-loader": "^1.7.1",
-		"eslint-plugin-react": "^4.2.3",
+		"eslint-plugin-import": "^2.7.0",
+		"eslint-plugin-jsx-a11y": "^5.1.1",
+		"eslint-plugin-react": "^7.3.0",
 		"expose-loader": "^0.7.3",
 		"extract-text-webpack-plugin": "^2.1.0",
 		"file-loader": "^0.11.1",
@@ -53,11 +54,14 @@
 		"postcss-load-config": "^1.2.0",
 		"postcss-loader": "^2.0.5",
 		"resolve-url-loader": "^2.0.2",
-		"sass-lint": "^1.9.1",
+		"sass-lint": "^1.11.1",
 		"sass-loader": "^6.0.5",
 		"script-loader": "^0.7.0",
 		"url-loader": "^0.5.8",
 		"webpack": "^2.6.1"
+	},
+	"resolutions": {
+		"eslint": "^4.6.1"
 	},
 	"jest": {
 		"roots": [
@@ -76,8 +80,7 @@
 	},
 	"babel": {
 		"presets": [
-			"es2015",
-			"es2016",
+			["env", { "modules": false }],
 			"react"
 		],
 		"plugins": [


### PR DESCRIPTION
So that we no longer need to go yearly upgrade for ES standards
Update eslint rules to latest available - turned off some into a `todo` variable to do for later

An attempt to clean up react practices in framework :) https://github.com/silverstripe/silverstripe-framework/issues/6427