### PR TITLE
Style-loader enabled

### DIFF
--- a/css/modules.js
+++ b/css/modules.js
@@ -105,7 +105,7 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }, { useStyle } = {}) => {
           : undefined,
       },
       {
-        test: /\.(png|gif|jpg|svg)$/,
+        test: /\.(png|gif|jpe?g|svg)$/,
         exclude: /fonts\/([\w_-]+)\.svg$/,
         loader: 'url-loader',
         options: {

--- a/css/modules.js
+++ b/css/modules.js
@@ -24,10 +24,19 @@ const SUPPORTED_BROWSERS = [
  * @param {string} SRC The path to the source scss files
  * @param {string} ROOT The path to the root of the project, this is so we can scope for
  * silverstripe-admin variables.scss
+ * @param {boolean} useStyle Determines whether to use the style loader or extract text plugin
  * @returns {{rules: [*,*,*,*]}}
  */
-module.exports = (ENV, { FILES_PATH, SRC, ROOT }) => {
+module.exports = (ENV, { FILES_PATH, SRC, ROOT }, { useStyle } = {}) => {
   const cssLoaders = [
+    (useStyle)
+      ? ({
+        loader: 'style-loader',
+        options: {
+          sourceMap: true,
+        },
+      })
+      : null,
     {
       loader: 'css-loader',
       options: {
@@ -45,40 +54,55 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }) => {
         ],
       },
     },
+  ].filter(loader => loader);
+  const scssLoaders = [
+    ...cssLoaders,
+    {
+      loader: 'resolve-url-loader',
+    },
+    {
+      loader: 'sass-loader',
+      options: {
+        includePaths: [
+          Path.resolve(SRC, 'styles'),
+          Path.resolve(ROOT, 'vendor/silverstripe/admin/client/src/styles'),
+          Path.resolve(ROOT, '../admin/client/src/styles'),
+          Path.resolve(ROOT, '../../silverstripe/admin/client/src/styles'),
+        ],
+        sourceMap: true,
+      },
+    },
   ];
 
   return {
     rules: [
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract({
-          publicPath: FILES_PATH,
-          use: [
-            ...cssLoaders,
-            {
-              loader: 'resolve-url-loader',
-            },
-            {
-              loader: 'sass-loader',
-              options: {
-                includePaths: [
-                  Path.resolve(SRC, 'styles'),
-                  Path.resolve(ROOT, 'vendor/silverstripe/admin/client/src/styles'),
-                  Path.resolve(ROOT, '../admin/client/src/styles'),
-                  Path.resolve(ROOT, '../../silverstripe/admin/client/src/styles'),
-                ],
-                sourceMap: true,
-              },
-            },
-          ],
-        }),
+        loader: useStyle
+          ? undefined
+          : (
+            ExtractTextPlugin.extract({
+              publicPath: FILES_PATH,
+              use: scssLoaders,
+            })
+          ),
+        use: useStyle
+          ? scssLoaders
+          : undefined,
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract({
-          publicPath: FILES_PATH,
-          use: cssLoaders,
-        }),
+        loader: useStyle
+          ? undefined
+          : (
+            ExtractTextPlugin.extract({
+              publicPath: FILES_PATH,
+              use: cssLoaders,
+            })
+          ),
+        use: useStyle
+          ? cssLoaders
+          : undefined,
       },
       {
         test: /\.(png|gif|jpg|svg)$/,

--- a/js/modules.js
+++ b/js/modules.js
@@ -28,6 +28,14 @@ module.exports = (ENV, { MODULES, THIRDPARTY }) => {
         },
       },
       {
+        test: /\.(png|gif|jpe?g|svg)$/,
+        exclude: /fonts\/([\w_-]+)\.svg$/,
+        loader: 'file-loader',
+        options: {
+          name: 'images/[name].[ext]',
+        },
+      },
+      {
         test: '/i18n.js/',
         use: 'script-loader',
       },

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -23,7 +23,7 @@ module.exports = (ENV) => {
     new webpack.DefinePlugin({
       'process.env': {
         // Builds React in production mode, avoiding console warnings
-        NODE_ENV: JSON.stringify(ENV),
+        NODE_ENV: JSON.stringify(ENV || 'development'),
       },
     }),
     uglifyPlugin,


### PR DESCRIPTION
Added flag to switch to style-loader instead of using ExtractTextPlugin
Added NODE_ENV to default as 'development'

This enables us to utilise hot-loading with CSS.

This is a part of the work put in to achieve dev hot-loading and component pattern-library using storybook.