### PR TITLE
NEW Allow non-SilverStripe vendor modules to resolve admin stylesheets

### DIFF
--- a/css/modules.js
+++ b/css/modules.js
@@ -65,6 +65,7 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }) => {
                   Path.resolve(SRC, 'styles'),
                   Path.resolve(ROOT, 'vendor/silverstripe/admin/client/src/styles'),
                   Path.resolve(ROOT, '../admin/client/src/styles'),
+                  Path.resolve(ROOT, '../../silverstripe/admin/client/src/styles'),
                 ],
                 sourceMap: true,
               },


### PR DESCRIPTION
Allows vendor modules that aren't under "silverstripe" to use admin stylesheets/variables.