### PR TITLE
Add jsx extension

### DIFF
--- a/js/resolve.js
+++ b/js/resolve.js
@@ -9,6 +9,7 @@
  */
 module.exports = (ENV, { ROOT, MODULES, SRC }) => ({
   modules: [ROOT, SRC, MODULES],
+  extensions: ['.json', '.js', '.jsx'],
   alias: {
     modernizr$: `${SRC}/.modernizrrc`,
   },


### PR DESCRIPTION
Add `jsx` as an extension to automatically resolve.
The webpack default is `[".js", ".json"]`, this simply adds `".jsx"` to that.