### PR TITLE
NEW Add Loading indicator from silverstripe/admin 1.2.x as external

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -50,6 +50,7 @@ module.exports = () => ({
   'components/Preview/Preview': 'Preview',
   'components/ListGroup/ListGroup': 'ListGroup',
   'components/ListGroup/ListGroupItem': 'ListGroupItem',
+  'components/Loading/Loading': 'Loading',
   'components/FormAlert/FormAlert': 'FormAlert',
   'components/Badge/Badge': 'Badge',
   'components/TreeDropdownField/TreeDropdownField': 'TreeDropdownField',


### PR DESCRIPTION
I don't want to have to do this. Someone please tell me a better way! Also, will this break for SS 4.0 and 4.1 users that install this version of webpack config?

Required for other modules to use https://github.com/silverstripe/silverstripe-admin/pull/490