### PR TITLE
Add support for windows dirs and woff2

### DIFF
--- a/css/modules.js
+++ b/css/modules.js
@@ -106,7 +106,7 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }, { useStyle } = {}) => {
       },
       {
         test: /\.(png|gif|jpe?g|svg)$/,
-        exclude: /fonts[\///]([\w_-]+)\.svg$/,
+        exclude: /fonts[\/\\]([\w_-]+)\.svg$/,
         loader: 'url-loader',
         options: {
           limit: 10000,
@@ -114,7 +114,7 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }, { useStyle } = {}) => {
         },
       },
       {
-        test: /fonts[\///]([\w_-]+)\.(woff|eot|ttf|svg)$/,
+        test: /fonts[\/\\]([\w_-]+)\.(woff2?|eot|ttf|svg)$/,
         loader: 'file-loader',
         options: {
           name: 'fonts/[name].[ext]',

--- a/js/modules.js
+++ b/js/modules.js
@@ -29,7 +29,7 @@ module.exports = (ENV, { MODULES, THIRDPARTY }) => {
       },
       {
         test: /\.(png|gif|jpe?g|svg)$/,
-        exclude: /fonts[\///]([\w_-]+)\.svg$/,
+        exclude: /fonts[\/\\]([\w_-]+)\.svg$/,
         loader: 'file-loader',
         options: {
           name: 'images/[name].[ext]',


### PR DESCRIPTION
Currently, any fonts loaded on windows file systems cause an error 

> You may need an appropriate loader to handle this file type.

This is because the regex checking assumes a unix directory separator.

Also adjusted file loader to match `.woff` and `.woff2`