### PR TITLE
NEW Expose TabsActions

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -71,6 +71,7 @@ module.exports = () => ({
   'state/schema/SchemaActions': 'SchemaActions',
   'state/records/RecordsActions': 'RecordsActions',
   'state/records/RecordsActionTypes': 'RecordsActionTypes',
+  'state/tabs/TabsActions': 'TabsActions',
   'state/viewMode/ViewModeActions': 'ViewModeActions',
   'lib/DataFormat': 'DataFormat',
   'lib/Backend': 'Backend',


### PR DESCRIPTION
The change in this PR exposes `TabActions` so that they can be used within the `Element` component of https://github.com/dnadesign/silverstripe-elemental


Related ticket: https://github.com/dnadesign/silverstripe-elemental/issues/448