### PR TITLE
NEW Exposing withDragDropContext HOC for ReactDND

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -87,4 +87,5 @@ module.exports = () => ({
   'lib/reduxFieldReducer': 'reduxFieldReducer',
   'lib/TinyMCEActionRegistrar': 'TinyMCEActionRegistrar',
   'lib/ShortcodeSerialiser': 'ShortcodeSerialiser',
+  'lib/withDragDropContext': 'withDragDropContext',
 });


### PR DESCRIPTION
This allows the HOC to provide only one DragDropContext for multiple drag areas. Currently you cannot have more than one.

See silverstripe/silverstripe-admin#711 for the admin PR implementing this HOC.