### PR TITLE
Add postcss-custom-properties for CSS Variable backwards compatibility

### DIFF
--- a/css/modules.js
+++ b/css/modules.js
@@ -1,5 +1,6 @@
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
+const customProperties = require('postcss-custom-properties');
 const Path = require('path');
 
 // Used for autoprefixing css properties (same as Bootstrap Aplha.2 defaults)
@@ -51,6 +52,7 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }, { useStyle } = {}) => {
         sourceMap: true,
         plugins: [
           autoprefixer({ browsers: SUPPORTED_BROWSERS }),
+          customProperties,
         ],
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
 			"requires": {
-				"acorn": "^4.0.3"
+				"acorn": "4.0.13"
 			},
 			"dependencies": {
 				"acorn": {
@@ -34,7 +34,7 @@
 			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -49,13 +49,13 @@
 			"resolved": "http://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
 			"integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
 			"requires": {
-				"assert": "^1.3.0",
-				"camelcase": "^1.2.1",
-				"loader-utils": "^1.1.0",
-				"lodash.assign": "^4.0.1",
-				"lodash.defaults": "^3.1.2",
-				"object-path": "^0.9.2",
-				"regex-parser": "^2.2.9"
+				"assert": "1.4.1",
+				"camelcase": "1.2.1",
+				"loader-utils": "1.1.0",
+				"lodash.assign": "4.2.0",
+				"lodash.defaults": "3.1.2",
+				"object-path": "0.9.2",
+				"regex-parser": "2.2.9"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -68,8 +68,8 @@
 					"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
 					"integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
 					"requires": {
-						"lodash.assign": "^3.0.0",
-						"lodash.restparam": "^3.0.0"
+						"lodash.assign": "3.2.0",
+						"lodash.restparam": "3.6.1"
 					},
 					"dependencies": {
 						"lodash.assign": {
@@ -77,9 +77,9 @@
 							"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
 							"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
 							"requires": {
-								"lodash._baseassign": "^3.0.0",
-								"lodash._createassigner": "^3.0.0",
-								"lodash.keys": "^3.0.0"
+								"lodash._baseassign": "3.2.0",
+								"lodash._createassigner": "3.1.1",
+								"lodash.keys": "3.1.2"
 							}
 						}
 					}
@@ -91,10 +91,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"align-text": {
@@ -102,9 +102,9 @@
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -112,7 +112,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -142,8 +142,8 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"aproba": {
@@ -156,8 +156,8 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"argparse": {
@@ -165,7 +165,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -193,7 +193,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -216,7 +216,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "~2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"asn1.js": {
@@ -224,9 +224,9 @@
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"assert": {
@@ -252,7 +252,7 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "4.17.11"
 			}
 		},
 		"async-each": {
@@ -285,12 +285,12 @@
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
 			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
 			"requires": {
-				"browserslist": "^1.7.6",
-				"caniuse-db": "^1.0.30000634",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^5.2.16",
-				"postcss-value-parser": "^3.2.3"
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000890",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"aws-sign2": {
@@ -308,9 +308,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"babel-core": {
@@ -318,25 +318,25 @@
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.6.0",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.11",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			}
 		},
 		"babel-generator": {
@@ -344,14 +344,14 @@
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.11",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -359,7 +359,7 @@
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 					"requires": {
-						"repeating": "^2.0.0"
+						"repeating": "2.0.1"
 					}
 				}
 			}
@@ -369,9 +369,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -379,9 +379,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"esutils": "2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -389,10 +389,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -400,10 +400,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -411,9 +411,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -421,11 +421,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -433,8 +433,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -442,8 +442,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -451,8 +451,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -460,9 +460,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -470,11 +470,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -482,12 +482,12 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -495,8 +495,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-loader": {
@@ -504,9 +504,9 @@
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
 			"integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
 			"requires": {
-				"find-cache-dir": "^1.0.0",
-				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1"
+				"find-cache-dir": "1.0.0",
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1"
 			}
 		},
 		"babel-messages": {
@@ -514,7 +514,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -522,7 +522,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -560,9 +560,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -570,7 +570,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -578,7 +578,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -586,11 +586,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -598,15 +598,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -614,8 +614,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -623,7 +623,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -631,8 +631,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -640,7 +640,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -648,9 +648,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -658,7 +658,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -666,9 +666,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -676,10 +676,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -687,9 +687,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -697,9 +697,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -707,8 +707,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -716,12 +716,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -729,8 +729,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -738,7 +738,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -746,9 +746,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -756,7 +756,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -764,7 +764,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -772,9 +772,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -782,9 +782,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -792,8 +792,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -801,8 +801,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -810,7 +810,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -818,9 +818,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-react-jsx": "6.26.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
@@ -828,8 +828,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -837,8 +837,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -846,7 +846,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "^0.10.0"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -854,8 +854,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-preset-env": {
@@ -863,36 +863,36 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
 			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^3.2.6",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"browserslist": "3.2.8",
+				"invariant": "2.2.4",
+				"semver": "5.6.0"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -900,8 +900,8 @@
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
 					"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
 					"requires": {
-						"caniuse-lite": "^1.0.30000844",
-						"electron-to-chromium": "^1.3.47"
+						"caniuse-lite": "1.0.30000890",
+						"electron-to-chromium": "1.3.77"
 					}
 				}
 			}
@@ -911,7 +911,7 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.22.0"
+				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
 		},
 		"babel-preset-react": {
@@ -919,12 +919,12 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-react-display-name": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0",
-				"babel-preset-flow": "^6.23.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-self": "6.22.0",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-preset-flow": "6.23.0"
 			}
 		},
 		"babel-register": {
@@ -932,13 +932,13 @@
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.7",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.11",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			}
 		},
 		"babel-runtime": {
@@ -946,8 +946,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.7",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -955,11 +955,11 @@
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-traverse": {
@@ -967,15 +967,15 @@
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.11"
 			},
 			"dependencies": {
 				"globals": {
@@ -990,10 +990,10 @@
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.11",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -1011,13 +1011,13 @@
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1025,7 +1025,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1033,7 +1033,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1041,7 +1041,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1049,9 +1049,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -1067,7 +1067,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"big.js": {
@@ -1085,7 +1085,7 @@
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"requires": {
-				"inherits": "~2.0.0"
+				"inherits": "2.0.3"
 			}
 		},
 		"bn.js": {
@@ -1098,7 +1098,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1107,16 +1107,16 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
+				"arr-flatten": "1.1.0",
+				"array-unique": "0.3.2",
+				"extend-shallow": "2.0.1",
+				"fill-range": "4.0.0",
+				"isobject": "3.0.1",
+				"repeat-element": "1.1.3",
+				"snapdragon": "0.8.2",
+				"snapdragon-node": "2.1.1",
+				"split-string": "3.1.0",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -1124,7 +1124,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -1139,12 +1139,12 @@
 			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"browserify-cipher": {
@@ -1152,9 +1152,9 @@
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
+				"browserify-aes": "1.2.0",
+				"browserify-des": "1.0.2",
+				"evp_bytestokey": "1.0.3"
 			}
 		},
 		"browserify-des": {
@@ -1162,10 +1162,10 @@
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"browserify-rsa": {
@@ -1173,8 +1173,8 @@
 			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.6"
 			}
 		},
 		"browserify-sign": {
@@ -1182,13 +1182,13 @@
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"elliptic": "6.4.1",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.1"
 			}
 		},
 		"browserify-zlib": {
@@ -1196,7 +1196,7 @@
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
-				"pako": "~1.0.5"
+				"pako": "1.0.6"
 			}
 		},
 		"browserslist": {
@@ -1204,8 +1204,8 @@
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
 			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 			"requires": {
-				"caniuse-db": "^1.0.30000639",
-				"electron-to-chromium": "^1.2.7"
+				"caniuse-db": "1.0.30000890",
+				"electron-to-chromium": "1.3.77"
 			}
 		},
 		"buffer": {
@@ -1213,9 +1213,9 @@
 			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "1.3.0",
+				"ieee754": "1.1.12",
+				"isarray": "1.0.0"
 			}
 		},
 		"buffer-from": {
@@ -1243,15 +1243,15 @@
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			}
 		},
 		"caller-path": {
@@ -1259,7 +1259,7 @@
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			}
 		},
 		"callsites": {
@@ -1277,8 +1277,8 @@
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1293,10 +1293,10 @@
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
 			"requires": {
-				"browserslist": "^1.3.6",
-				"caniuse-db": "^1.0.30000529",
-				"lodash.memoize": "^4.1.2",
-				"lodash.uniq": "^4.5.0"
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000890",
+				"lodash.memoize": "4.1.2",
+				"lodash.uniq": "4.5.0"
 			}
 		},
 		"caniuse-db": {
@@ -1319,8 +1319,8 @@
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
 			}
 		},
 		"chalk": {
@@ -1328,11 +1328,11 @@
 			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -1347,19 +1347,19 @@
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
 			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
 			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
-				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"anymatch": "2.0.0",
+				"async-each": "1.0.1",
+				"braces": "2.3.2",
+				"fsevents": "1.2.4",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.0",
+				"lodash.debounce": "4.0.8",
+				"normalize-path": "2.1.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.2.1",
+				"upath": "1.1.0"
 			}
 		},
 		"cipher-base": {
@@ -1367,8 +1367,8 @@
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"circular-json": {
@@ -1381,7 +1381,7 @@
 			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
 			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
 			"requires": {
-				"chalk": "^1.1.3"
+				"chalk": "1.1.3"
 			}
 		},
 		"class-utils": {
@@ -1389,10 +1389,10 @@
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1400,7 +1400,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -1415,9 +1415,9 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
 			}
 		},
 		"clone": {
@@ -1430,10 +1430,10 @@
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
 			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
 			"requires": {
-				"for-own": "^1.0.0",
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.0",
-				"shallow-clone": "^1.0.0"
+				"for-own": "1.0.0",
+				"is-plain-object": "2.0.4",
+				"kind-of": "6.0.2",
+				"shallow-clone": "1.0.0"
 			}
 		},
 		"co": {
@@ -1446,7 +1446,7 @@
 			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
 			"requires": {
-				"q": "^1.1.2"
+				"q": "1.5.1"
 			}
 		},
 		"code-point-at": {
@@ -1459,8 +1459,8 @@
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color": {
@@ -1468,9 +1468,9 @@
 			"resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
 			"requires": {
-				"clone": "^1.0.2",
-				"color-convert": "^1.3.0",
-				"color-string": "^0.3.0"
+				"clone": "1.0.4",
+				"color-convert": "1.9.3",
+				"color-string": "0.3.0"
 			}
 		},
 		"color-convert": {
@@ -1491,7 +1491,7 @@
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
 			"requires": {
-				"color-name": "^1.0.0"
+				"color-name": "1.1.3"
 			}
 		},
 		"colormin": {
@@ -1499,9 +1499,9 @@
 			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
 			"requires": {
-				"color": "^0.11.0",
+				"color": "0.11.4",
 				"css-color-names": "0.0.4",
-				"has": "^1.0.1"
+				"has": "1.0.3"
 			}
 		},
 		"combined-stream": {
@@ -1509,7 +1509,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -1537,10 +1537,10 @@
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"buffer-from": "1.1.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"typedarray": "0.0.6"
 			}
 		},
 		"console-browserify": {
@@ -1548,7 +1548,7 @@
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"requires": {
-				"date-now": "^0.1.4"
+				"date-now": "0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -1566,7 +1566,7 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
 			"requires": {
-				"safe-buffer": "~5.1.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"copy-descriptor": {
@@ -1589,13 +1589,13 @@
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
 			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
 			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.4.3",
-				"minimist": "^1.2.0",
-				"object-assign": "^4.1.0",
-				"os-homedir": "^1.0.1",
-				"parse-json": "^2.2.0",
-				"require-from-string": "^1.1.0"
+				"is-directory": "0.3.1",
+				"js-yaml": "3.7.0",
+				"minimist": "1.2.0",
+				"object-assign": "4.1.1",
+				"os-homedir": "1.0.2",
+				"parse-json": "2.2.0",
+				"require-from-string": "1.2.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -1610,8 +1610,8 @@
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.1"
 			}
 		},
 		"create-hash": {
@@ -1619,11 +1619,11 @@
 			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"md5.js": "1.3.5",
+				"ripemd160": "2.0.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"create-hmac": {
@@ -1631,12 +1631,12 @@
 			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"crypto-browserify": {
@@ -1644,17 +1644,17 @@
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
+				"browserify-cipher": "1.0.1",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.3",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"diffie-hellman": "5.0.3",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.17",
+				"public-encrypt": "4.0.3",
+				"randombytes": "2.0.6",
+				"randomfill": "1.0.4"
 			}
 		},
 		"css": {
@@ -1662,10 +1662,10 @@
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
 			"requires": {
-				"inherits": "^2.0.3",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.5.2",
-				"urix": "^0.1.0"
+				"inherits": "2.0.3",
+				"source-map": "0.6.1",
+				"source-map-resolve": "0.5.2",
+				"urix": "0.1.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -1685,20 +1685,20 @@
 			"resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
 			"integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"css-selector-tokenizer": "^0.7.0",
-				"cssnano": "^3.10.0",
-				"icss-utils": "^2.1.0",
-				"loader-utils": "^1.0.2",
-				"lodash.camelcase": "^4.3.0",
-				"object-assign": "^4.1.1",
-				"postcss": "^5.0.6",
-				"postcss-modules-extract-imports": "^1.2.0",
-				"postcss-modules-local-by-default": "^1.2.0",
-				"postcss-modules-scope": "^1.1.0",
-				"postcss-modules-values": "^1.3.0",
-				"postcss-value-parser": "^3.3.0",
-				"source-list-map": "^2.0.0"
+				"babel-code-frame": "6.26.0",
+				"css-selector-tokenizer": "0.7.0",
+				"cssnano": "3.10.0",
+				"icss-utils": "2.1.0",
+				"loader-utils": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-modules-extract-imports": "1.2.0",
+				"postcss-modules-local-by-default": "1.2.0",
+				"postcss-modules-scope": "1.1.0",
+				"postcss-modules-values": "1.3.0",
+				"postcss-value-parser": "3.3.0",
+				"source-list-map": "2.0.1"
 			}
 		},
 		"css-selector-tokenizer": {
@@ -1706,9 +1706,9 @@
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
 			"requires": {
-				"cssesc": "^0.1.0",
-				"fastparse": "^1.1.1",
-				"regexpu-core": "^1.0.0"
+				"cssesc": "0.1.0",
+				"fastparse": "1.1.1",
+				"regexpu-core": "1.0.0"
 			},
 			"dependencies": {
 				"regexpu-core": {
@@ -1716,9 +1716,9 @@
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
 					"requires": {
-						"regenerate": "^1.2.1",
-						"regjsgen": "^0.2.0",
-						"regjsparser": "^0.1.4"
+						"regenerate": "1.4.0",
+						"regjsgen": "0.2.0",
+						"regjsparser": "0.1.5"
 					}
 				}
 			}
@@ -1733,38 +1733,38 @@
 			"resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
 			"requires": {
-				"autoprefixer": "^6.3.1",
-				"decamelize": "^1.1.2",
-				"defined": "^1.0.0",
-				"has": "^1.0.1",
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.14",
-				"postcss-calc": "^5.2.0",
-				"postcss-colormin": "^2.1.8",
-				"postcss-convert-values": "^2.3.4",
-				"postcss-discard-comments": "^2.0.4",
-				"postcss-discard-duplicates": "^2.0.1",
-				"postcss-discard-empty": "^2.0.1",
-				"postcss-discard-overridden": "^0.1.1",
-				"postcss-discard-unused": "^2.2.1",
-				"postcss-filter-plugins": "^2.0.0",
-				"postcss-merge-idents": "^2.1.5",
-				"postcss-merge-longhand": "^2.0.1",
-				"postcss-merge-rules": "^2.0.3",
-				"postcss-minify-font-values": "^1.0.2",
-				"postcss-minify-gradients": "^1.0.1",
-				"postcss-minify-params": "^1.0.4",
-				"postcss-minify-selectors": "^2.0.4",
-				"postcss-normalize-charset": "^1.1.0",
-				"postcss-normalize-url": "^3.0.7",
-				"postcss-ordered-values": "^2.1.0",
-				"postcss-reduce-idents": "^2.2.2",
-				"postcss-reduce-initial": "^1.0.0",
-				"postcss-reduce-transforms": "^1.0.3",
-				"postcss-svgo": "^2.1.1",
-				"postcss-unique-selectors": "^2.0.2",
-				"postcss-value-parser": "^3.2.3",
-				"postcss-zindex": "^2.0.1"
+				"autoprefixer": "6.7.7",
+				"decamelize": "1.2.0",
+				"defined": "1.0.0",
+				"has": "1.0.3",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-calc": "5.3.1",
+				"postcss-colormin": "2.2.2",
+				"postcss-convert-values": "2.6.1",
+				"postcss-discard-comments": "2.0.4",
+				"postcss-discard-duplicates": "2.1.0",
+				"postcss-discard-empty": "2.1.0",
+				"postcss-discard-overridden": "0.1.1",
+				"postcss-discard-unused": "2.2.3",
+				"postcss-filter-plugins": "2.0.3",
+				"postcss-merge-idents": "2.1.7",
+				"postcss-merge-longhand": "2.0.2",
+				"postcss-merge-rules": "2.1.2",
+				"postcss-minify-font-values": "1.0.5",
+				"postcss-minify-gradients": "1.0.5",
+				"postcss-minify-params": "1.2.2",
+				"postcss-minify-selectors": "2.1.1",
+				"postcss-normalize-charset": "1.1.1",
+				"postcss-normalize-url": "3.0.8",
+				"postcss-ordered-values": "2.2.3",
+				"postcss-reduce-idents": "2.4.0",
+				"postcss-reduce-initial": "1.0.1",
+				"postcss-reduce-transforms": "1.0.4",
+				"postcss-svgo": "2.1.6",
+				"postcss-unique-selectors": "2.0.2",
+				"postcss-value-parser": "3.3.0",
+				"postcss-zindex": "2.2.0"
 			}
 		},
 		"csso": {
@@ -1772,8 +1772,8 @@
 			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
 			"requires": {
-				"clap": "^1.0.9",
-				"source-map": "^0.5.3"
+				"clap": "1.2.3",
+				"source-map": "0.5.7"
 			}
 		},
 		"currently-unhandled": {
@@ -1781,7 +1781,7 @@
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"d": {
@@ -1789,7 +1789,7 @@
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"requires": {
-				"es5-ext": "^0.10.9"
+				"es5-ext": "0.10.46"
 			}
 		},
 		"dashdash": {
@@ -1797,7 +1797,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"date-now": {
@@ -1833,8 +1833,8 @@
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -1842,7 +1842,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1850,7 +1850,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1858,9 +1858,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -1875,13 +1875,13 @@
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
 			},
 			"dependencies": {
 				"pify": {
@@ -1906,8 +1906,8 @@
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"diffie-hellman": {
@@ -1915,9 +1915,9 @@
 			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.6"
 			}
 		},
 		"doctrine": {
@@ -1925,8 +1925,8 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.3.tgz",
 			"integrity": "sha1-auxrvWLPid1JjK5wwO2fSdqHOmo=",
 			"requires": {
-				"esutils": "^2.0.2",
-				"isarray": "^1.0.0"
+				"esutils": "2.0.2",
+				"isarray": "1.0.0"
 			}
 		},
 		"domain-browser": {
@@ -1940,8 +1940,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"electron-to-chromium": {
@@ -1954,13 +1954,13 @@
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
 			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.5",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"emojis-list": {
@@ -1973,10 +1973,10 @@
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"object-assign": "^4.0.1",
-				"tapable": "^0.2.7"
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
 			}
 		},
 		"errno": {
@@ -1984,7 +1984,7 @@
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
-				"prr": "~1.0.1"
+				"prr": "1.0.1"
 			}
 		},
 		"error-ex": {
@@ -1992,7 +1992,7 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es5-ext": {
@@ -2000,9 +2000,9 @@
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
 			"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
 			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"next-tick": "1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -2010,9 +2010,9 @@
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-symbol": "3.1.1"
 			}
 		},
 		"es6-map": {
@@ -2020,12 +2020,12 @@
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-set": "~0.1.5",
-				"es6-symbol": "~3.1.1",
-				"event-emitter": "~0.3.5"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
 			}
 		},
 		"es6-set": {
@@ -2033,11 +2033,11 @@
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-iterator": "2.0.3",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
+				"event-emitter": "0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -2045,8 +2045,8 @@
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46"
 			}
 		},
 		"es6-weak-map": {
@@ -2054,10 +2054,10 @@
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
-				"es6-symbol": "^3.1.1"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -2070,10 +2070,10 @@
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"requires": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"espree": {
@@ -2081,8 +2081,8 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.7.3",
+				"acorn-jsx": "3.0.1"
 			}
 		},
 		"esprima": {
@@ -2095,7 +2095,7 @@
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -2113,8 +2113,8 @@
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "1.0.0",
+				"es5-ext": "0.10.46"
 			}
 		},
 		"events": {
@@ -2127,8 +2127,8 @@
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
+				"md5.js": "1.3.5",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"exit-hook": {
@@ -2141,13 +2141,13 @@
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2155,7 +2155,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -2163,7 +2163,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2183,8 +2183,8 @@
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -2192,7 +2192,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -2202,14 +2202,14 @@
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2217,7 +2217,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -2225,7 +2225,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2233,7 +2233,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2241,7 +2241,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2249,9 +2249,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2261,10 +2261,10 @@
 			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
 			"integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
 			"requires": {
-				"async": "^2.1.2",
-				"loader-utils": "^1.0.2",
-				"schema-utils": "^0.3.0",
-				"webpack-sources": "^1.0.1"
+				"async": "2.6.1",
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0",
+				"webpack-sources": "1.3.0"
 			}
 		},
 		"extsprintf": {
@@ -2302,7 +2302,7 @@
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
 			"integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
 			"requires": {
-				"loader-utils": "^1.0.2"
+				"loader-utils": "1.1.0"
 			}
 		},
 		"fill-range": {
@@ -2310,10 +2310,10 @@
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"extend-shallow": "2.0.1",
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1",
+				"to-regex-range": "2.1.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -2321,7 +2321,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2331,9 +2331,9 @@
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "1.3.0",
+				"pkg-dir": "2.0.0"
 			}
 		},
 		"find-parent-dir": {
@@ -2346,7 +2346,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -2354,10 +2354,10 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			}
 		},
 		"flatten": {
@@ -2375,7 +2375,7 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
 			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"forever-agent": {
@@ -2388,9 +2388,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.20"
 			},
 			"dependencies": {
 				"combined-stream": {
@@ -2398,7 +2398,7 @@
 					"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				}
 			}
@@ -2408,7 +2408,7 @@
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"front-matter": {
@@ -2416,7 +2416,7 @@
 			"resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz",
 			"integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
 			"requires": {
-				"js-yaml": "^3.4.6"
+				"js-yaml": "3.7.0"
 			}
 		},
 		"fs-extra": {
@@ -2424,9 +2424,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
 			"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^3.0.0",
-				"universalify": "^0.1.0"
+				"graceful-fs": "4.1.11",
+				"jsonfile": "3.0.1",
+				"universalify": "0.1.2"
 			}
 		},
 		"fs.realpath": {
@@ -2440,8 +2440,8 @@
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "2.11.1",
+				"node-pre-gyp": "0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2463,8 +2463,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -2475,7 +2475,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -2529,7 +2529,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -2542,14 +2542,14 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -2557,12 +2557,12 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -2575,7 +2575,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -2583,7 +2583,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -2591,8 +2591,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -2608,7 +2608,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -2620,7 +2620,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -2631,8 +2631,8 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -2640,7 +2640,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -2660,9 +2660,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -2670,16 +2670,16 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.7",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -2687,8 +2687,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -2701,8 +2701,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -2710,10 +2710,10 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2729,7 +2729,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2747,8 +2747,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -2766,10 +2766,10 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2784,13 +2784,13 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -2798,7 +2798,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -2834,9 +2834,9 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -2844,14 +2844,14 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -2864,13 +2864,13 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -2883,7 +2883,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -2901,10 +2901,10 @@
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
+				"graceful-fs": "4.1.11",
+				"inherits": "2.0.3",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"function-bind": {
@@ -2917,14 +2917,14 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
+				"aproba": "1.2.0",
+				"console-control-strings": "1.1.0",
+				"has-unicode": "2.0.1",
+				"object-assign": "4.1.1",
+				"signal-exit": "3.0.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wide-align": "1.1.3"
 			}
 		},
 		"gaze": {
@@ -2932,7 +2932,7 @@
 			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
 			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"requires": {
-				"globule": "^1.0.0"
+				"globule": "1.2.1"
 			}
 		},
 		"generate-function": {
@@ -2940,7 +2940,7 @@
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
 			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
 			"requires": {
-				"is-property": "^1.0.2"
+				"is-property": "1.0.2"
 			}
 		},
 		"generate-object-property": {
@@ -2948,7 +2948,7 @@
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 			"requires": {
-				"is-property": "^1.0.0"
+				"is-property": "1.0.2"
 			}
 		},
 		"get-caller-file": {
@@ -2971,7 +2971,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
@@ -2979,12 +2979,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-parent": {
@@ -2992,8 +2992,8 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
 			},
 			"dependencies": {
 				"is-glob": {
@@ -3001,7 +3001,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"requires": {
-						"is-extglob": "^2.1.0"
+						"is-extglob": "2.1.1"
 					}
 				}
 			}
@@ -3011,12 +3011,12 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"requires": {
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.3",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -3031,9 +3031,9 @@
 			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
 			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
 			"requires": {
-				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
-				"minimatch": "~3.0.2"
+				"glob": "7.1.3",
+				"lodash": "4.17.11",
+				"minimatch": "3.0.4"
 			}
 		},
 		"gonzales-pe-sl": {
@@ -3041,7 +3041,7 @@
 			"resolved": "https://registry.npmjs.org/gonzales-pe-sl/-/gonzales-pe-sl-4.2.3.tgz",
 			"integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
 			"requires": {
-				"minimist": "1.1.x"
+				"minimist": "1.1.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -3066,8 +3066,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -3075,7 +3075,7 @@
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"requires": {
-				"function-bind": "^1.1.1"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -3083,7 +3083,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -3101,9 +3101,9 @@
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			}
 		},
 		"has-values": {
@@ -3111,8 +3111,8 @@
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3120,7 +3120,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3130,8 +3130,8 @@
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"hash.js": {
@@ -3139,8 +3139,8 @@
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
 			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
 			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"hmac-drbg": {
@@ -3148,9 +3148,9 @@
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hash.js": "1.1.5",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"home-or-tmp": {
@@ -3158,8 +3158,8 @@
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -3177,9 +3177,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.2"
 			}
 		},
 		"https-browserify": {
@@ -3197,7 +3197,7 @@
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
 			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -3205,7 +3205,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.3"
 					}
 				},
 				"chalk": {
@@ -3213,9 +3213,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"has-flag": {
@@ -3228,9 +3228,9 @@
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"source-map": {
@@ -3243,7 +3243,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -3263,7 +3263,7 @@
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
 			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
 			"requires": {
-				"import-from": "^2.1.0"
+				"import-from": "2.1.0"
 			}
 		},
 		"import-from": {
@@ -3271,7 +3271,7 @@
 			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
 			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -3286,8 +3286,8 @@
 			"resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
 			"integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
 			"requires": {
-				"loader-utils": "0.2.x",
-				"source-map": "0.1.x"
+				"loader-utils": "0.2.17",
+				"source-map": "0.1.43"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -3295,10 +3295,10 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
 					}
 				},
 				"source-map": {
@@ -3306,7 +3306,7 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
 					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -3326,7 +3326,7 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"indexes-of": {
@@ -3344,8 +3344,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -3363,7 +3363,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"invert-kv": {
@@ -3381,7 +3381,7 @@
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3389,7 +3389,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3404,7 +3404,7 @@
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.12.0"
 			}
 		},
 		"is-buffer": {
@@ -3417,7 +3417,7 @@
 			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-data-descriptor": {
@@ -3425,7 +3425,7 @@
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3433,7 +3433,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3443,9 +3443,9 @@
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3475,7 +3475,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -3483,7 +3483,7 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-glob": {
@@ -3491,7 +3491,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 			"requires": {
-				"is-extglob": "^2.1.1"
+				"is-extglob": "2.1.1"
 			}
 		},
 		"is-my-ip-valid": {
@@ -3504,11 +3504,11 @@
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
 			"integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
 			"requires": {
-				"generate-function": "^2.0.0",
-				"generate-object-property": "^1.1.0",
-				"is-my-ip-valid": "^1.0.0",
-				"jsonpointer": "^4.0.0",
-				"xtend": "^4.0.0"
+				"generate-function": "2.3.1",
+				"generate-object-property": "1.2.0",
+				"is-my-ip-valid": "1.0.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"is-number": {
@@ -3516,7 +3516,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3524,7 +3524,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3539,7 +3539,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
@@ -3547,7 +3547,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -3560,7 +3560,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-property": {
@@ -3578,7 +3578,7 @@
 			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
 			"requires": {
-				"html-comment-regex": "^1.1.0"
+				"html-comment-regex": "1.1.2"
 			}
 		},
 		"is-typedarray": {
@@ -3631,8 +3631,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
 			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^2.6.0"
+				"argparse": "1.0.10",
+				"esprima": "2.7.3"
 			}
 		},
 		"jsbn": {
@@ -3671,7 +3671,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -3689,7 +3689,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
 			"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"jsonify": {
@@ -3733,7 +3733,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"levn": {
@@ -3741,8 +3741,8 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -3750,11 +3750,11 @@
 			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -3774,9 +3774,9 @@
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"requires": {
-				"big.js": "^3.1.3",
-				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
 			}
 		},
 		"locate-path": {
@@ -3784,8 +3784,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -3798,8 +3798,8 @@
 			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"requires": {
-				"lodash._basecopy": "^3.0.0",
-				"lodash.keys": "^3.0.0"
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
 			}
 		},
 		"lodash._basecopy": {
@@ -3817,9 +3817,9 @@
 			"resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
 			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
 			"requires": {
-				"lodash._bindcallback": "^3.0.0",
-				"lodash._isiterateecall": "^3.0.0",
-				"lodash.restparam": "^3.0.0"
+				"lodash._bindcallback": "3.0.1",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash.restparam": "3.6.1"
 			}
 		},
 		"lodash._getnative": {
@@ -3882,9 +3882,9 @@
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
 			}
 		},
 		"lodash.memoize": {
@@ -3922,7 +3922,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"loud-rejection": {
@@ -3930,8 +3930,8 @@
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -3939,8 +3939,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			},
 			"dependencies": {
 				"yallist": {
@@ -3955,7 +3955,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"map-cache": {
@@ -3973,7 +3973,7 @@
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"math-expression-evaluator": {
@@ -3986,9 +3986,9 @@
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"memory-fs": {
@@ -3996,8 +3996,8 @@
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
+				"errno": "0.1.7",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"meow": {
@@ -4005,16 +4005,16 @@
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -4034,19 +4034,19 @@
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"braces": "2.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"extglob": "2.0.4",
+				"fragment-cache": "0.2.1",
+				"kind-of": "6.0.2",
+				"nanomatch": "1.2.13",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"miller-rabin": {
@@ -4054,8 +4054,8 @@
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
 			}
 		},
 		"mime": {
@@ -4073,7 +4073,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
 			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"requires": {
-				"mime-db": "~1.36.0"
+				"mime-db": "1.36.0"
 			}
 		},
 		"minimalistic-assert": {
@@ -4091,7 +4091,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -4104,8 +4104,8 @@
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4113,7 +4113,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -4123,8 +4123,8 @@
 			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
+				"for-in": "0.1.8",
+				"is-extendable": "0.1.1"
 			},
 			"dependencies": {
 				"for-in": {
@@ -4152,7 +4152,7 @@
 				"find-parent-dir": "0.3.0",
 				"lodash": "4.17.4",
 				"mkdirp": "0.5.1",
-				"remarkable": "^1.6.2",
+				"remarkable": "1.7.1",
 				"requirejs": "2.1.22",
 				"yargs": "7.0.2"
 			},
@@ -4184,17 +4184,17 @@
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"neo-async": {
@@ -4212,18 +4212,18 @@
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"requires": {
-				"fstream": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^2.0.0",
-				"which": "1"
+				"fstream": "1.0.11",
+				"glob": "7.1.3",
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"npmlog": "4.1.2",
+				"osenv": "0.1.5",
+				"request": "2.87.0",
+				"rimraf": "2.6.2",
+				"semver": "5.3.0",
+				"tar": "2.2.1",
+				"which": "1.3.1"
 			},
 			"dependencies": {
 				"nopt": {
@@ -4231,7 +4231,7 @@
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 					"requires": {
-						"abbrev": "1"
+						"abbrev": "1.1.1"
 					}
 				},
 				"semver": {
@@ -4244,9 +4244,9 @@
 					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
 					}
 				}
 			}
@@ -4256,28 +4256,28 @@
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
-				"https-browserify": "^1.0.0",
-				"os-browserify": "^0.3.0",
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "^0.11.10",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.3.3",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.7.2",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.6",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.3",
+				"string_decoder": "1.1.1",
+				"timers-browserify": "2.0.10",
 				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"url": "0.11.0",
+				"util": "0.10.3",
 				"vm-browserify": "0.0.4"
 			}
 		},
@@ -4286,25 +4286,25 @@
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
 			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
 			"requires": {
-				"async-foreach": "^0.1.3",
-				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
-				"gaze": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
-				"node-gyp": "^3.8.0",
-				"npmlog": "^4.0.0",
+				"async-foreach": "0.1.3",
+				"chalk": "1.1.3",
+				"cross-spawn": "3.0.1",
+				"gaze": "1.1.3",
+				"get-stdin": "4.0.1",
+				"glob": "7.1.3",
+				"in-publish": "2.0.0",
+				"lodash.assign": "4.2.0",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.mergewith": "4.6.1",
+				"meow": "3.7.0",
+				"mkdirp": "0.5.1",
+				"nan": "2.11.1",
+				"node-gyp": "3.8.0",
+				"npmlog": "4.1.2",
 				"request": "2.87.0",
-				"sass-graph": "^2.2.4",
-				"stdout-stream": "^1.4.0",
-				"true-case-path": "^1.0.2"
+				"sass-graph": "2.2.4",
+				"stdout-stream": "1.4.1",
+				"true-case-path": "1.0.3"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -4312,8 +4312,8 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
 					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.3",
+						"which": "1.3.1"
 					}
 				}
 			}
@@ -4323,10 +4323,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.7.1",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.6.0",
+				"validate-npm-package-license": "3.0.4"
 			}
 		},
 		"normalize-path": {
@@ -4334,7 +4334,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"normalize-range": {
@@ -4347,10 +4347,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
 			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
+				"object-assign": "4.1.1",
+				"prepend-http": "1.0.4",
+				"query-string": "4.3.4",
+				"sort-keys": "1.1.2"
 			},
 			"dependencies": {
 				"query-string": {
@@ -4358,8 +4358,8 @@
 					"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
 					"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
 					"requires": {
-						"object-assign": "^4.1.0",
-						"strict-uri-encode": "^1.0.0"
+						"object-assign": "4.1.1",
+						"strict-uri-encode": "1.1.0"
 					}
 				},
 				"strict-uri-encode": {
@@ -4374,132 +4374,132 @@
 			"resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
 			"integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
 			"requires": {
-				"JSONStream": "^1.3.4",
-				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
-				"aproba": "~1.2.0",
-				"archy": "~1.0.0",
-				"bin-links": "^1.1.2",
-				"bluebird": "~3.5.1",
-				"byte-size": "^4.0.3",
-				"cacache": "^11.2.0",
-				"call-limit": "~1.1.0",
-				"chownr": "~1.0.1",
-				"ci-info": "^1.4.0",
-				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.5.0",
-				"cmd-shim": "~2.0.2",
-				"columnify": "~1.5.4",
-				"config-chain": "~1.1.11",
-				"debuglog": "*",
-				"detect-indent": "~5.0.0",
-				"detect-newline": "^2.1.0",
-				"dezalgo": "~1.0.3",
-				"editor": "~1.0.0",
-				"figgy-pudding": "^3.4.1",
-				"find-npm-prefix": "^1.0.2",
-				"fs-vacuum": "~1.2.10",
-				"fs-write-stream-atomic": "~1.0.10",
-				"gentle-fs": "^2.0.1",
-				"glob": "~7.1.2",
-				"graceful-fs": "~4.1.11",
-				"has-unicode": "~2.0.1",
-				"hosted-git-info": "^2.7.1",
-				"iferr": "^1.0.2",
-				"imurmurhash": "*",
-				"inflight": "~1.0.6",
-				"inherits": "~2.0.3",
-				"ini": "^1.3.5",
-				"init-package-json": "^1.10.3",
-				"is-cidr": "^2.0.6",
-				"json-parse-better-errors": "^1.0.2",
-				"lazy-property": "~1.0.0",
-				"libcipm": "^2.0.2",
-				"libnpmhook": "^4.0.1",
-				"libnpx": "^10.2.0",
-				"lock-verify": "^2.0.2",
-				"lockfile": "^1.0.4",
-				"lodash._baseindexof": "*",
-				"lodash._baseuniq": "~4.6.0",
-				"lodash._bindcallback": "*",
-				"lodash._cacheindexof": "*",
-				"lodash._createcache": "*",
-				"lodash._getnative": "*",
-				"lodash.clonedeep": "~4.5.0",
-				"lodash.restparam": "*",
-				"lodash.union": "~4.6.0",
-				"lodash.uniq": "~4.5.0",
-				"lodash.without": "~4.4.0",
-				"lru-cache": "^4.1.3",
-				"meant": "~1.0.1",
-				"mississippi": "^3.0.0",
-				"mkdirp": "~0.5.1",
-				"move-concurrently": "^1.0.1",
-				"node-gyp": "^3.8.0",
-				"nopt": "~4.0.1",
-				"normalize-package-data": "~2.4.0",
-				"npm-audit-report": "^1.3.1",
-				"npm-cache-filename": "~1.0.2",
-				"npm-install-checks": "~3.0.0",
-				"npm-lifecycle": "^2.1.0",
-				"npm-package-arg": "^6.1.0",
-				"npm-packlist": "^1.1.11",
-				"npm-pick-manifest": "^2.1.0",
-				"npm-profile": "^3.0.2",
-				"npm-registry-client": "^8.6.0",
-				"npm-registry-fetch": "^1.1.0",
-				"npm-user-validate": "~1.0.0",
-				"npmlog": "~4.1.2",
-				"once": "~1.4.0",
-				"opener": "^1.5.0",
-				"osenv": "^0.1.5",
-				"pacote": "^8.1.6",
-				"path-is-inside": "~1.0.2",
-				"promise-inflight": "~1.0.1",
-				"qrcode-terminal": "^0.12.0",
-				"query-string": "^6.1.0",
-				"qw": "~1.0.1",
-				"read": "~1.0.7",
-				"read-cmd-shim": "~1.0.1",
-				"read-installed": "~4.0.3",
-				"read-package-json": "^2.0.13",
-				"read-package-tree": "^5.2.1",
-				"readable-stream": "^2.3.6",
-				"readdir-scoped-modules": "*",
-				"request": "^2.88.0",
-				"retry": "^0.12.0",
-				"rimraf": "~2.6.2",
-				"safe-buffer": "^5.1.2",
-				"semver": "^5.5.0",
-				"sha": "~2.0.1",
-				"slide": "~1.1.6",
-				"sorted-object": "~2.0.1",
-				"sorted-union-stream": "~2.1.3",
-				"ssri": "^6.0.0",
-				"stringify-package": "^1.0.0",
-				"tar": "^4.4.6",
-				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
+				"JSONStream": "1.3.4",
+				"abbrev": "1.1.1",
+				"ansicolors": "0.3.2",
+				"ansistyles": "0.1.3",
+				"aproba": "1.2.0",
+				"archy": "1.0.0",
+				"bin-links": "1.1.2",
+				"bluebird": "3.5.1",
+				"byte-size": "4.0.3",
+				"cacache": "11.2.0",
+				"call-limit": "1.1.0",
+				"chownr": "1.0.1",
+				"ci-info": "1.4.0",
+				"cli-columns": "3.1.2",
+				"cli-table3": "0.5.0",
+				"cmd-shim": "2.0.2",
+				"columnify": "1.5.4",
+				"config-chain": "1.1.11",
+				"debuglog": "1.0.1",
+				"detect-indent": "5.0.0",
+				"detect-newline": "2.1.0",
+				"dezalgo": "1.0.3",
+				"editor": "1.0.0",
+				"figgy-pudding": "3.4.1",
+				"find-npm-prefix": "1.0.2",
+				"fs-vacuum": "1.2.10",
+				"fs-write-stream-atomic": "1.0.10",
+				"gentle-fs": "2.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"has-unicode": "2.0.1",
+				"hosted-git-info": "2.7.1",
+				"iferr": "1.0.2",
+				"imurmurhash": "0.1.4",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"ini": "1.3.5",
+				"init-package-json": "1.10.3",
+				"is-cidr": "2.0.6",
+				"json-parse-better-errors": "1.0.2",
+				"lazy-property": "1.0.0",
+				"libcipm": "2.0.2",
+				"libnpmhook": "4.0.1",
+				"libnpx": "10.2.0",
+				"lock-verify": "2.0.2",
+				"lockfile": "1.0.4",
+				"lodash._baseindexof": "3.1.0",
+				"lodash._baseuniq": "4.6.0",
+				"lodash._bindcallback": "3.0.1",
+				"lodash._cacheindexof": "3.0.2",
+				"lodash._createcache": "3.1.2",
+				"lodash._getnative": "3.9.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.restparam": "3.6.1",
+				"lodash.union": "4.6.0",
+				"lodash.uniq": "4.5.0",
+				"lodash.without": "4.4.0",
+				"lru-cache": "4.1.3",
+				"meant": "1.0.1",
+				"mississippi": "3.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"node-gyp": "3.8.0",
+				"nopt": "4.0.1",
+				"normalize-package-data": "2.4.0",
+				"npm-audit-report": "1.3.1",
+				"npm-cache-filename": "1.0.2",
+				"npm-install-checks": "3.0.0",
+				"npm-lifecycle": "2.1.0",
+				"npm-package-arg": "6.1.0",
+				"npm-packlist": "1.1.11",
+				"npm-pick-manifest": "2.1.0",
+				"npm-profile": "3.0.2",
+				"npm-registry-client": "8.6.0",
+				"npm-registry-fetch": "1.1.0",
+				"npm-user-validate": "1.0.0",
+				"npmlog": "4.1.2",
+				"once": "1.4.0",
+				"opener": "1.5.0",
+				"osenv": "0.1.5",
+				"pacote": "8.1.6",
+				"path-is-inside": "1.0.2",
+				"promise-inflight": "1.0.1",
+				"qrcode-terminal": "0.12.0",
+				"query-string": "6.1.0",
+				"qw": "1.0.1",
+				"read": "1.0.7",
+				"read-cmd-shim": "1.0.1",
+				"read-installed": "4.0.3",
+				"read-package-json": "2.0.13",
+				"read-package-tree": "5.2.1",
+				"readable-stream": "2.3.6",
+				"readdir-scoped-modules": "1.0.2",
+				"request": "2.88.0",
+				"retry": "0.12.0",
+				"rimraf": "2.6.2",
+				"safe-buffer": "5.1.2",
+				"semver": "5.5.0",
+				"sha": "2.0.1",
+				"slide": "1.1.6",
+				"sorted-object": "2.0.1",
+				"sorted-union-stream": "2.1.3",
+				"ssri": "6.0.0",
+				"stringify-package": "1.0.0",
+				"tar": "4.4.6",
+				"text-table": "0.2.0",
+				"tiny-relative-date": "1.3.0",
 				"uid-number": "0.0.6",
-				"umask": "~1.1.0",
-				"unique-filename": "~1.1.0",
-				"unpipe": "~1.0.0",
-				"update-notifier": "^2.5.0",
-				"uuid": "^3.3.2",
-				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "~3.0.0",
-				"which": "^1.3.1",
-				"worker-farm": "^1.6.0",
-				"write-file-atomic": "^2.3.0"
+				"umask": "1.1.0",
+				"unique-filename": "1.1.0",
+				"unpipe": "1.0.0",
+				"update-notifier": "2.5.0",
+				"uuid": "3.3.2",
+				"validate-npm-package-license": "3.0.4",
+				"validate-npm-package-name": "3.0.0",
+				"which": "1.3.1",
+				"worker-farm": "1.6.0",
+				"write-file-atomic": "2.3.0"
 			},
 			"dependencies": {
 				"JSONStream": {
 					"version": "1.3.4",
 					"bundled": true,
 					"requires": {
-						"jsonparse": "^1.2.0",
-						"through": ">=2.2.7 <3"
+						"jsonparse": "1.3.1",
+						"through": "2.3.8"
 					}
 				},
 				"abbrev": {
@@ -4510,31 +4510,31 @@
 					"version": "4.2.0",
 					"bundled": true,
 					"requires": {
-						"es6-promisify": "^5.0.0"
+						"es6-promisify": "5.0.0"
 					}
 				},
 				"agentkeepalive": {
 					"version": "3.4.1",
 					"bundled": true,
 					"requires": {
-						"humanize-ms": "^1.2.1"
+						"humanize-ms": "1.2.1"
 					}
 				},
 				"ajv": {
 					"version": "5.5.2",
 					"bundled": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"ansi-align": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "^2.0.0"
+						"string-width": "2.1.1"
 					}
 				},
 				"ansi-regex": {
@@ -4545,7 +4545,7 @@
 					"version": "3.2.1",
 					"bundled": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"ansicolors": {
@@ -4568,8 +4568,8 @@
 					"version": "1.1.4",
 					"bundled": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"asap": {
@@ -4580,7 +4580,7 @@
 					"version": "0.2.4",
 					"bundled": true,
 					"requires": {
-						"safer-buffer": "~2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"assert-plus": {
@@ -4608,25 +4608,25 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "^0.14.3"
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"bin-links": {
 					"version": "1.1.2",
 					"bundled": true,
 					"requires": {
-						"bluebird": "^3.5.0",
-						"cmd-shim": "^2.0.2",
-						"gentle-fs": "^2.0.0",
-						"graceful-fs": "^4.1.11",
-						"write-file-atomic": "^2.3.0"
+						"bluebird": "3.5.1",
+						"cmd-shim": "2.0.2",
+						"gentle-fs": "2.0.1",
+						"graceful-fs": "4.1.11",
+						"write-file-atomic": "2.3.0"
 					}
 				},
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
 					"requires": {
-						"inherits": "~2.0.0"
+						"inherits": "2.0.3"
 					}
 				},
 				"bluebird": {
@@ -4637,20 +4637,20 @@
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"ansi-align": "^2.0.0",
-						"camelcase": "^4.0.0",
-						"chalk": "^2.0.1",
-						"cli-boxes": "^1.0.0",
-						"string-width": "^2.0.0",
-						"term-size": "^1.2.0",
-						"widest-line": "^2.0.0"
+						"ansi-align": "2.0.0",
+						"camelcase": "4.1.0",
+						"chalk": "2.4.1",
+						"cli-boxes": "1.0.0",
+						"string-width": "2.1.1",
+						"term-size": "1.2.0",
+						"widest-line": "2.0.0"
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -4678,20 +4678,20 @@
 					"version": "11.2.0",
 					"bundled": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"figgy-pudding": "^3.1.0",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.3",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"ssri": "^6.0.0",
-						"unique-filename": "^1.1.0",
-						"y18n": "^4.0.0"
+						"bluebird": "3.5.1",
+						"chownr": "1.0.1",
+						"figgy-pudding": "3.4.1",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"lru-cache": "4.1.3",
+						"mississippi": "3.0.0",
+						"mkdirp": "0.5.1",
+						"move-concurrently": "1.0.1",
+						"promise-inflight": "1.0.1",
+						"rimraf": "2.6.2",
+						"ssri": "6.0.0",
+						"unique-filename": "1.1.0",
+						"y18n": "4.0.0"
 					}
 				},
 				"call-limit": {
@@ -4714,9 +4714,9 @@
 					"version": "2.4.1",
 					"bundled": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"chownr": {
@@ -4731,7 +4731,7 @@
 					"version": "2.0.9",
 					"bundled": true,
 					"requires": {
-						"ip-regex": "^2.1.0"
+						"ip-regex": "2.1.0"
 					}
 				},
 				"cli-boxes": {
@@ -4742,26 +4742,26 @@
 					"version": "3.1.2",
 					"bundled": true,
 					"requires": {
-						"string-width": "^2.0.0",
-						"strip-ansi": "^3.0.1"
+						"string-width": "2.1.1",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"cli-table3": {
 					"version": "0.5.0",
 					"bundled": true,
 					"requires": {
-						"colors": "^1.1.2",
-						"object-assign": "^4.1.0",
-						"string-width": "^2.1.1"
+						"colors": "1.1.2",
+						"object-assign": "4.1.1",
+						"string-width": "2.1.1"
 					}
 				},
 				"cliui": {
 					"version": "4.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -4772,7 +4772,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -4785,8 +4785,8 @@
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "~0.5.0"
+						"graceful-fs": "4.1.11",
+						"mkdirp": "0.5.1"
 					}
 				},
 				"co": {
@@ -4801,7 +4801,7 @@
 					"version": "1.9.1",
 					"bundled": true,
 					"requires": {
-						"color-name": "^1.1.1"
+						"color-name": "1.1.3"
 					}
 				},
 				"color-name": {
@@ -4817,15 +4817,15 @@
 					"version": "1.5.4",
 					"bundled": true,
 					"requires": {
-						"strip-ansi": "^3.0.0",
-						"wcwidth": "^1.0.0"
+						"strip-ansi": "3.0.1",
+						"wcwidth": "1.0.1"
 					}
 				},
 				"combined-stream": {
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
@@ -4836,30 +4836,30 @@
 					"version": "1.6.2",
 					"bundled": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.2",
-						"typedarray": "^0.0.6"
+						"buffer-from": "1.0.0",
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.6",
+						"typedarray": "0.0.6"
 					}
 				},
 				"config-chain": {
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"ini": "^1.3.4",
-						"proto-list": "~1.2.1"
+						"ini": "1.3.5",
+						"proto-list": "1.2.4"
 					}
 				},
 				"configstore": {
 					"version": "3.1.2",
 					"bundled": true,
 					"requires": {
-						"dot-prop": "^4.1.0",
-						"graceful-fs": "^4.1.2",
-						"make-dir": "^1.0.0",
-						"unique-string": "^1.0.0",
-						"write-file-atomic": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
+						"dot-prop": "4.2.0",
+						"graceful-fs": "4.1.11",
+						"make-dir": "1.3.0",
+						"unique-string": "1.0.0",
+						"write-file-atomic": "2.3.0",
+						"xdg-basedir": "3.0.0"
 					}
 				},
 				"console-control-strings": {
@@ -4870,12 +4870,12 @@
 					"version": "1.0.5",
 					"bundled": true,
 					"requires": {
-						"aproba": "^1.1.1",
-						"fs-write-stream-atomic": "^1.0.8",
-						"iferr": "^0.1.5",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.5.4",
-						"run-queue": "^1.0.0"
+						"aproba": "1.2.0",
+						"fs-write-stream-atomic": "1.0.10",
+						"iferr": "0.1.5",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"run-queue": "1.0.3"
 					},
 					"dependencies": {
 						"iferr": {
@@ -4892,16 +4892,16 @@
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"capture-stack-trace": "^1.0.0"
+						"capture-stack-trace": "1.0.0"
 					}
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.3",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				},
 				"crypto-random-string": {
@@ -4916,7 +4916,7 @@
 					"version": "1.14.1",
 					"bundled": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					}
 				},
 				"debug": {
@@ -4952,7 +4952,7 @@
 					"version": "1.0.3",
 					"bundled": true,
 					"requires": {
-						"clone": "^1.0.2"
+						"clone": "1.0.4"
 					}
 				},
 				"delayed-stream": {
@@ -4975,15 +4975,15 @@
 					"version": "1.0.3",
 					"bundled": true,
 					"requires": {
-						"asap": "^2.0.0",
-						"wrappy": "1"
+						"asap": "2.0.6",
+						"wrappy": "1.0.2"
 					}
 				},
 				"dot-prop": {
 					"version": "4.2.0",
 					"bundled": true,
 					"requires": {
-						"is-obj": "^1.0.0"
+						"is-obj": "1.0.1"
 					}
 				},
 				"dotenv": {
@@ -4998,10 +4998,10 @@
 					"version": "3.6.0",
 					"bundled": true,
 					"requires": {
-						"end-of-stream": "^1.0.0",
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0",
-						"stream-shift": "^1.0.0"
+						"end-of-stream": "1.4.1",
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.6",
+						"stream-shift": "1.0.0"
 					}
 				},
 				"ecc-jsbn": {
@@ -5009,8 +5009,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0",
-						"safer-buffer": "^2.1.0"
+						"jsbn": "0.1.1",
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"editor": {
@@ -5021,14 +5021,14 @@
 					"version": "0.1.12",
 					"bundled": true,
 					"requires": {
-						"iconv-lite": "~0.4.13"
+						"iconv-lite": "0.4.23"
 					}
 				},
 				"end-of-stream": {
 					"version": "1.4.1",
 					"bundled": true,
 					"requires": {
-						"once": "^1.4.0"
+						"once": "1.4.0"
 					}
 				},
 				"err-code": {
@@ -5039,7 +5039,7 @@
 					"version": "0.1.7",
 					"bundled": true,
 					"requires": {
-						"prr": "~1.0.1"
+						"prr": "1.0.1"
 					}
 				},
 				"es6-promise": {
@@ -5050,7 +5050,7 @@
 					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
-						"es6-promise": "^4.0.3"
+						"es6-promise": "4.2.4"
 					}
 				},
 				"escape-string-regexp": {
@@ -5061,13 +5061,13 @@
 					"version": "0.7.0",
 					"bundled": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"extend": {
@@ -5098,15 +5098,15 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"flush-write-stream": {
 					"version": "1.0.3",
 					"bundled": true,
 					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.4"
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"forever-agent": {
@@ -5117,43 +5117,43 @@
 					"version": "2.3.2",
 					"bundled": true,
 					"requires": {
-						"asynckit": "^0.4.0",
+						"asynckit": "0.4.0",
 						"combined-stream": "1.0.6",
-						"mime-types": "^2.1.12"
+						"mime-types": "2.1.19"
 					}
 				},
 				"from2": {
 					"version": "2.3.0",
 					"bundled": true,
 					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0"
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.3.3"
 					}
 				},
 				"fs-vacuum": {
 					"version": "1.2.10",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"path-is-inside": "^1.0.1",
-						"rimraf": "^2.5.2"
+						"graceful-fs": "4.1.11",
+						"path-is-inside": "1.0.2",
+						"rimraf": "2.6.2"
 					}
 				},
 				"fs-write-stream-atomic": {
 					"version": "1.0.10",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"iferr": "^0.1.5",
-						"imurmurhash": "^0.1.4",
-						"readable-stream": "1 || 2"
+						"graceful-fs": "4.1.11",
+						"iferr": "0.1.5",
+						"imurmurhash": "0.1.4",
+						"readable-stream": "2.3.6"
 					},
 					"dependencies": {
 						"iferr": {
@@ -5170,33 +5170,33 @@
 					"version": "1.0.11",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2"
 					}
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					},
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -5209,14 +5209,14 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"aproba": "^1.1.2",
-						"fs-vacuum": "^1.2.10",
-						"graceful-fs": "^4.1.11",
-						"iferr": "^0.1.5",
-						"mkdirp": "^0.5.1",
-						"path-is-inside": "^1.0.2",
-						"read-cmd-shim": "^1.0.1",
-						"slide": "^1.1.6"
+						"aproba": "1.2.0",
+						"fs-vacuum": "1.2.10",
+						"graceful-fs": "4.1.11",
+						"iferr": "0.1.5",
+						"mkdirp": "0.5.1",
+						"path-is-inside": "1.0.2",
+						"read-cmd-shim": "1.0.1",
+						"slide": "1.1.6"
 					},
 					"dependencies": {
 						"iferr": {
@@ -5237,43 +5237,43 @@
 					"version": "0.1.7",
 					"bundled": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					}
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"global-dirs": {
 					"version": "0.1.1",
 					"bundled": true,
 					"requires": {
-						"ini": "^1.3.4"
+						"ini": "1.3.5"
 					}
 				},
 				"got": {
 					"version": "6.7.1",
 					"bundled": true,
 					"requires": {
-						"create-error-class": "^3.0.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-redirect": "^1.0.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"lowercase-keys": "^1.0.0",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"unzip-response": "^2.0.1",
-						"url-parse-lax": "^1.0.0"
+						"create-error-class": "3.0.2",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-redirect": "1.0.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"lowercase-keys": "1.0.1",
+						"safe-buffer": "5.1.2",
+						"timed-out": "4.0.1",
+						"unzip-response": "2.0.1",
+						"url-parse-lax": "1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -5288,8 +5288,8 @@
 					"version": "5.1.0",
 					"bundled": true,
 					"requires": {
-						"ajv": "^5.3.0",
-						"har-schema": "^2.0.0"
+						"ajv": "5.5.2",
+						"har-schema": "2.0.0"
 					}
 				},
 				"has-flag": {
@@ -5312,7 +5312,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"agent-base": "4",
+						"agent-base": "4.2.0",
 						"debug": "3.1.0"
 					}
 				},
@@ -5320,31 +5320,31 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"assert-plus": "^1.0.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "1.0.0",
+						"jsprim": "1.4.1",
+						"sshpk": "1.14.2"
 					}
 				},
 				"https-proxy-agent": {
 					"version": "2.2.1",
 					"bundled": true,
 					"requires": {
-						"agent-base": "^4.1.0",
-						"debug": "^3.1.0"
+						"agent-base": "4.2.0",
+						"debug": "3.1.0"
 					}
 				},
 				"humanize-ms": {
 					"version": "1.2.1",
 					"bundled": true,
 					"requires": {
-						"ms": "^2.0.0"
+						"ms": "2.1.1"
 					}
 				},
 				"iconv-lite": {
 					"version": "0.4.23",
 					"bundled": true,
 					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"iferr": {
@@ -5355,7 +5355,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"import-lazy": {
@@ -5370,8 +5370,8 @@
 					"version": "1.0.6",
 					"bundled": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -5386,14 +5386,14 @@
 					"version": "1.10.3",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.1.1",
-						"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-						"promzard": "^0.3.0",
-						"read": "~1.0.1",
-						"read-package-json": "1 || 2",
-						"semver": "2.x || 3.x || 4 || 5",
-						"validate-npm-package-license": "^3.0.1",
-						"validate-npm-package-name": "^3.0.0"
+						"glob": "7.1.2",
+						"npm-package-arg": "6.1.0",
+						"promzard": "0.3.0",
+						"read": "1.0.7",
+						"read-package-json": "2.0.13",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.4",
+						"validate-npm-package-name": "3.0.0"
 					}
 				},
 				"invert-kv": {
@@ -5412,36 +5412,36 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"builtin-modules": "^1.0.0"
+						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-ci": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"ci-info": "^1.0.0"
+						"ci-info": "1.4.0"
 					}
 				},
 				"is-cidr": {
 					"version": "2.0.6",
 					"bundled": true,
 					"requires": {
-						"cidr-regex": "^2.0.8"
+						"cidr-regex": "2.0.9"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
 					"bundled": true,
 					"requires": {
-						"global-dirs": "^0.1.0",
-						"is-path-inside": "^1.0.0"
+						"global-dirs": "0.1.1",
+						"is-path-inside": "1.0.1"
 					}
 				},
 				"is-npm": {
@@ -5456,7 +5456,7 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"path-is-inside": "^1.0.1"
+						"path-is-inside": "1.0.2"
 					}
 				},
 				"is-redirect": {
@@ -5526,7 +5526,7 @@
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"package-json": "^4.0.0"
+						"package-json": "4.0.1"
 					}
 				},
 				"lazy-property": {
@@ -5537,46 +5537,46 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"invert-kv": "^1.0.0"
+						"invert-kv": "1.0.0"
 					}
 				},
 				"libcipm": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"bin-links": "^1.1.2",
-						"bluebird": "^3.5.1",
-						"find-npm-prefix": "^1.0.2",
-						"graceful-fs": "^4.1.11",
-						"lock-verify": "^2.0.2",
-						"mkdirp": "^0.5.1",
-						"npm-lifecycle": "^2.0.3",
-						"npm-logical-tree": "^1.2.1",
-						"npm-package-arg": "^6.1.0",
-						"pacote": "^8.1.6",
-						"protoduck": "^5.0.0",
-						"read-package-json": "^2.0.13",
-						"rimraf": "^2.6.2",
-						"worker-farm": "^1.6.0"
+						"bin-links": "1.1.2",
+						"bluebird": "3.5.1",
+						"find-npm-prefix": "1.0.2",
+						"graceful-fs": "4.1.11",
+						"lock-verify": "2.0.2",
+						"mkdirp": "0.5.1",
+						"npm-lifecycle": "2.1.0",
+						"npm-logical-tree": "1.2.1",
+						"npm-package-arg": "6.1.0",
+						"pacote": "8.1.6",
+						"protoduck": "5.0.0",
+						"read-package-json": "2.0.13",
+						"rimraf": "2.6.2",
+						"worker-farm": "1.6.0"
 					}
 				},
 				"libnpmhook": {
 					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
-						"figgy-pudding": "^3.1.0",
-						"npm-registry-fetch": "^3.0.0"
+						"figgy-pudding": "3.4.1",
+						"npm-registry-fetch": "3.1.1"
 					},
 					"dependencies": {
 						"npm-registry-fetch": {
 							"version": "3.1.1",
 							"bundled": true,
 							"requires": {
-								"bluebird": "^3.5.1",
-								"figgy-pudding": "^3.1.0",
-								"lru-cache": "^4.1.2",
-								"make-fetch-happen": "^4.0.0",
-								"npm-package-arg": "^6.0.0"
+								"bluebird": "3.5.1",
+								"figgy-pudding": "3.4.1",
+								"lru-cache": "4.1.3",
+								"make-fetch-happen": "4.0.1",
+								"npm-package-arg": "6.1.0"
 							}
 						}
 					}
@@ -5585,37 +5585,37 @@
 					"version": "10.2.0",
 					"bundled": true,
 					"requires": {
-						"dotenv": "^5.0.1",
-						"npm-package-arg": "^6.0.0",
-						"rimraf": "^2.6.2",
-						"safe-buffer": "^5.1.0",
-						"update-notifier": "^2.3.0",
-						"which": "^1.3.0",
-						"y18n": "^4.0.0",
-						"yargs": "^11.0.0"
+						"dotenv": "5.0.1",
+						"npm-package-arg": "6.1.0",
+						"rimraf": "2.6.2",
+						"safe-buffer": "5.1.2",
+						"update-notifier": "2.5.0",
+						"which": "1.3.1",
+						"y18n": "4.0.0",
+						"yargs": "11.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"lock-verify": {
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"npm-package-arg": "^5.1.2 || 6",
-						"semver": "^5.4.1"
+						"npm-package-arg": "6.1.0",
+						"semver": "5.5.0"
 					}
 				},
 				"lockfile": {
 					"version": "1.0.4",
 					"bundled": true,
 					"requires": {
-						"signal-exit": "^3.0.2"
+						"signal-exit": "3.0.2"
 					}
 				},
 				"lodash._baseindexof": {
@@ -5626,8 +5626,8 @@
 					"version": "4.6.0",
 					"bundled": true,
 					"requires": {
-						"lodash._createset": "~4.0.0",
-						"lodash._root": "~3.0.0"
+						"lodash._createset": "4.0.3",
+						"lodash._root": "3.0.1"
 					}
 				},
 				"lodash._bindcallback": {
@@ -5642,7 +5642,7 @@
 					"version": "3.1.2",
 					"bundled": true,
 					"requires": {
-						"lodash._getnative": "^3.0.0"
+						"lodash._getnative": "3.9.1"
 					}
 				},
 				"lodash._createset": {
@@ -5685,32 +5685,32 @@
 					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
 				},
 				"make-dir": {
 					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"make-fetch-happen": {
 					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
-						"agentkeepalive": "^3.4.1",
-						"cacache": "^11.0.1",
-						"http-cache-semantics": "^3.8.1",
-						"http-proxy-agent": "^2.1.0",
-						"https-proxy-agent": "^2.2.1",
-						"lru-cache": "^4.1.2",
-						"mississippi": "^3.0.0",
-						"node-fetch-npm": "^2.0.2",
-						"promise-retry": "^1.1.1",
-						"socks-proxy-agent": "^4.0.0",
-						"ssri": "^6.0.0"
+						"agentkeepalive": "3.4.1",
+						"cacache": "11.2.0",
+						"http-cache-semantics": "3.8.1",
+						"http-proxy-agent": "2.1.0",
+						"https-proxy-agent": "2.2.1",
+						"lru-cache": "4.1.3",
+						"mississippi": "3.0.0",
+						"node-fetch-npm": "2.0.2",
+						"promise-retry": "1.1.1",
+						"socks-proxy-agent": "4.0.1",
+						"ssri": "6.0.0"
 					}
 				},
 				"meant": {
@@ -5721,7 +5721,7 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"mime-db": {
@@ -5732,7 +5732,7 @@
 					"version": "2.1.19",
 					"bundled": true,
 					"requires": {
-						"mime-db": "~1.35.0"
+						"mime-db": "1.35.0"
 					}
 				},
 				"mimic-fn": {
@@ -5743,7 +5743,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -5754,8 +5754,8 @@
 					"version": "2.3.3",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.2"
 					},
 					"dependencies": {
 						"yallist": {
@@ -5768,23 +5768,23 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.3.3"
 					}
 				},
 				"mississippi": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"concat-stream": "^1.5.0",
-						"duplexify": "^3.4.2",
-						"end-of-stream": "^1.1.0",
-						"flush-write-stream": "^1.0.0",
-						"from2": "^2.1.0",
-						"parallel-transform": "^1.1.0",
-						"pump": "^3.0.0",
-						"pumpify": "^1.3.3",
-						"stream-each": "^1.1.0",
-						"through2": "^2.0.0"
+						"concat-stream": "1.6.2",
+						"duplexify": "3.6.0",
+						"end-of-stream": "1.4.1",
+						"flush-write-stream": "1.0.3",
+						"from2": "2.3.0",
+						"parallel-transform": "1.1.0",
+						"pump": "3.0.0",
+						"pumpify": "1.5.1",
+						"stream-each": "1.2.2",
+						"through2": "2.0.3"
 					}
 				},
 				"mkdirp": {
@@ -5798,12 +5798,12 @@
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"aproba": "^1.1.1",
-						"copy-concurrently": "^1.0.0",
-						"fs-write-stream-atomic": "^1.0.8",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.5.4",
-						"run-queue": "^1.0.3"
+						"aproba": "1.2.0",
+						"copy-concurrently": "1.0.5",
+						"fs-write-stream-atomic": "1.0.10",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"run-queue": "1.0.3"
 					}
 				},
 				"ms": {
@@ -5818,34 +5818,34 @@
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"encoding": "^0.1.11",
-						"json-parse-better-errors": "^1.0.0",
-						"safe-buffer": "^5.1.1"
+						"encoding": "0.1.12",
+						"json-parse-better-errors": "1.0.2",
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"node-gyp": {
 					"version": "3.8.0",
 					"bundled": true,
 					"requires": {
-						"fstream": "^1.0.0",
-						"glob": "^7.0.3",
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "^0.5.0",
-						"nopt": "2 || 3",
-						"npmlog": "0 || 1 || 2 || 3 || 4",
-						"osenv": "0",
-						"request": "^2.87.0",
-						"rimraf": "2",
-						"semver": "~5.3.0",
-						"tar": "^2.0.0",
-						"which": "1"
+						"fstream": "1.0.11",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"mkdirp": "0.5.1",
+						"nopt": "3.0.6",
+						"npmlog": "4.1.2",
+						"osenv": "0.1.5",
+						"request": "2.88.0",
+						"rimraf": "2.6.2",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"which": "1.3.1"
 					},
 					"dependencies": {
 						"nopt": {
 							"version": "3.0.6",
 							"bundled": true,
 							"requires": {
-								"abbrev": "1"
+								"abbrev": "1.1.1"
 							}
 						},
 						"semver": {
@@ -5856,9 +5856,9 @@
 							"version": "2.2.1",
 							"bundled": true,
 							"requires": {
-								"block-stream": "*",
-								"fstream": "^1.0.2",
-								"inherits": "2"
+								"block-stream": "0.0.9",
+								"fstream": "1.0.11",
+								"inherits": "2.0.3"
 							}
 						}
 					}
@@ -5867,26 +5867,26 @@
 					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"is-builtin-module": "^1.0.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
+						"hosted-git-info": "2.7.1",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.4"
 					}
 				},
 				"npm-audit-report": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"cli-table3": "^0.5.0",
-						"console-control-strings": "^1.1.0"
+						"cli-table3": "0.5.0",
+						"console-control-strings": "1.1.0"
 					}
 				},
 				"npm-bundled": {
@@ -5901,21 +5901,21 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"semver": "^2.3.0 || 3.x || 4 || 5"
+						"semver": "5.5.0"
 					}
 				},
 				"npm-lifecycle": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"byline": "^5.0.0",
-						"graceful-fs": "^4.1.11",
-						"node-gyp": "^3.8.0",
-						"resolve-from": "^4.0.0",
-						"slide": "^1.1.6",
+						"byline": "5.0.0",
+						"graceful-fs": "4.1.11",
+						"node-gyp": "3.8.0",
+						"resolve-from": "4.0.0",
+						"slide": "1.1.6",
 						"uid-number": "0.0.6",
-						"umask": "^1.1.0",
-						"which": "^1.3.1"
+						"umask": "1.1.0",
+						"which": "1.3.1"
 					}
 				},
 				"npm-logical-tree": {
@@ -5926,52 +5926,52 @@
 					"version": "6.1.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "^2.6.0",
-						"osenv": "^0.1.5",
-						"semver": "^5.5.0",
-						"validate-npm-package-name": "^3.0.0"
+						"hosted-git-info": "2.7.1",
+						"osenv": "0.1.5",
+						"semver": "5.5.0",
+						"validate-npm-package-name": "3.0.0"
 					}
 				},
 				"npm-packlist": {
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.5"
 					}
 				},
 				"npm-pick-manifest": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"npm-package-arg": "^6.0.0",
-						"semver": "^5.4.1"
+						"npm-package-arg": "6.1.0",
+						"semver": "5.5.0"
 					}
 				},
 				"npm-profile": {
 					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"aproba": "^1.1.2 || 2",
-						"make-fetch-happen": "^2.5.0 || 3 || 4"
+						"aproba": "1.2.0",
+						"make-fetch-happen": "4.0.1"
 					}
 				},
 				"npm-registry-client": {
 					"version": "8.6.0",
 					"bundled": true,
 					"requires": {
-						"concat-stream": "^1.5.2",
-						"graceful-fs": "^4.1.6",
-						"normalize-package-data": "~1.0.1 || ^2.0.0",
-						"npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-						"npmlog": "2 || ^3.1.0 || ^4.0.0",
-						"once": "^1.3.3",
-						"request": "^2.74.0",
-						"retry": "^0.10.0",
-						"safe-buffer": "^5.1.1",
-						"semver": "2 >=2.2.1 || 3.x || 4 || 5",
-						"slide": "^1.1.3",
-						"ssri": "^5.2.4"
+						"concat-stream": "1.6.2",
+						"graceful-fs": "4.1.11",
+						"normalize-package-data": "2.4.0",
+						"npm-package-arg": "6.1.0",
+						"npmlog": "4.1.2",
+						"once": "1.4.0",
+						"request": "2.88.0",
+						"retry": "0.10.1",
+						"safe-buffer": "5.1.2",
+						"semver": "5.5.0",
+						"slide": "1.1.6",
+						"ssri": "5.3.0"
 					},
 					"dependencies": {
 						"retry": {
@@ -5982,7 +5982,7 @@
 							"version": "5.3.0",
 							"bundled": true,
 							"requires": {
-								"safe-buffer": "^5.1.1"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -5991,47 +5991,47 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"figgy-pudding": "^2.0.1",
-						"lru-cache": "^4.1.2",
-						"make-fetch-happen": "^3.0.0",
-						"npm-package-arg": "^6.0.0",
-						"safe-buffer": "^5.1.1"
+						"bluebird": "3.5.1",
+						"figgy-pudding": "2.0.1",
+						"lru-cache": "4.1.3",
+						"make-fetch-happen": "3.0.0",
+						"npm-package-arg": "6.1.0",
+						"safe-buffer": "5.1.2"
 					},
 					"dependencies": {
 						"cacache": {
 							"version": "10.0.4",
 							"bundled": true,
 							"requires": {
-								"bluebird": "^3.5.1",
-								"chownr": "^1.0.1",
-								"glob": "^7.1.2",
-								"graceful-fs": "^4.1.11",
-								"lru-cache": "^4.1.1",
-								"mississippi": "^2.0.0",
-								"mkdirp": "^0.5.1",
-								"move-concurrently": "^1.0.1",
-								"promise-inflight": "^1.0.1",
-								"rimraf": "^2.6.2",
-								"ssri": "^5.2.4",
-								"unique-filename": "^1.1.0",
-								"y18n": "^4.0.0"
+								"bluebird": "3.5.1",
+								"chownr": "1.0.1",
+								"glob": "7.1.2",
+								"graceful-fs": "4.1.11",
+								"lru-cache": "4.1.3",
+								"mississippi": "2.0.0",
+								"mkdirp": "0.5.1",
+								"move-concurrently": "1.0.1",
+								"promise-inflight": "1.0.1",
+								"rimraf": "2.6.2",
+								"ssri": "5.3.0",
+								"unique-filename": "1.1.0",
+								"y18n": "4.0.0"
 							},
 							"dependencies": {
 								"mississippi": {
 									"version": "2.0.0",
 									"bundled": true,
 									"requires": {
-										"concat-stream": "^1.5.0",
-										"duplexify": "^3.4.2",
-										"end-of-stream": "^1.1.0",
-										"flush-write-stream": "^1.0.0",
-										"from2": "^2.1.0",
-										"parallel-transform": "^1.1.0",
-										"pump": "^2.0.1",
-										"pumpify": "^1.3.3",
-										"stream-each": "^1.1.0",
-										"through2": "^2.0.0"
+										"concat-stream": "1.6.2",
+										"duplexify": "3.6.0",
+										"end-of-stream": "1.4.1",
+										"flush-write-stream": "1.0.3",
+										"from2": "2.3.0",
+										"parallel-transform": "1.1.0",
+										"pump": "2.0.1",
+										"pumpify": "1.5.1",
+										"stream-each": "1.2.2",
+										"through2": "2.0.3"
 									}
 								}
 							}
@@ -6044,25 +6044,25 @@
 							"version": "3.0.0",
 							"bundled": true,
 							"requires": {
-								"agentkeepalive": "^3.4.1",
-								"cacache": "^10.0.4",
-								"http-cache-semantics": "^3.8.1",
-								"http-proxy-agent": "^2.1.0",
-								"https-proxy-agent": "^2.2.0",
-								"lru-cache": "^4.1.2",
-								"mississippi": "^3.0.0",
-								"node-fetch-npm": "^2.0.2",
-								"promise-retry": "^1.1.1",
-								"socks-proxy-agent": "^3.0.1",
-								"ssri": "^5.2.4"
+								"agentkeepalive": "3.4.1",
+								"cacache": "10.0.4",
+								"http-cache-semantics": "3.8.1",
+								"http-proxy-agent": "2.1.0",
+								"https-proxy-agent": "2.2.1",
+								"lru-cache": "4.1.3",
+								"mississippi": "3.0.0",
+								"node-fetch-npm": "2.0.2",
+								"promise-retry": "1.1.1",
+								"socks-proxy-agent": "3.0.1",
+								"ssri": "5.3.0"
 							}
 						},
 						"pump": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
+								"end-of-stream": "1.4.1",
+								"once": "1.4.0"
 							}
 						},
 						"smart-buffer": {
@@ -6073,23 +6073,23 @@
 							"version": "1.1.10",
 							"bundled": true,
 							"requires": {
-								"ip": "^1.1.4",
-								"smart-buffer": "^1.0.13"
+								"ip": "1.1.5",
+								"smart-buffer": "1.1.15"
 							}
 						},
 						"socks-proxy-agent": {
 							"version": "3.0.1",
 							"bundled": true,
 							"requires": {
-								"agent-base": "^4.1.0",
-								"socks": "^1.1.10"
+								"agent-base": "4.2.0",
+								"socks": "1.1.10"
 							}
 						},
 						"ssri": {
 							"version": "5.3.0",
 							"bundled": true,
 							"requires": {
-								"safe-buffer": "^5.1.1"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -6098,7 +6098,7 @@
 					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"path-key": "^2.0.0"
+						"path-key": "2.0.1"
 					}
 				},
 				"npm-user-validate": {
@@ -6109,10 +6109,10 @@
 					"version": "4.1.2",
 					"bundled": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -6131,7 +6131,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"opener": {
@@ -6146,9 +6146,9 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"os-tmpdir": {
@@ -6159,8 +6159,8 @@
 					"version": "0.1.5",
 					"bundled": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"p-finally": {
@@ -6171,14 +6171,14 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.2.0"
 					}
 				},
 				"p-try": {
@@ -6189,50 +6189,50 @@
 					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
-						"got": "^6.7.1",
-						"registry-auth-token": "^3.0.1",
-						"registry-url": "^3.0.3",
-						"semver": "^5.1.0"
+						"got": "6.7.1",
+						"registry-auth-token": "3.3.2",
+						"registry-url": "3.1.0",
+						"semver": "5.5.0"
 					}
 				},
 				"pacote": {
 					"version": "8.1.6",
 					"bundled": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"cacache": "^11.0.2",
-						"get-stream": "^3.0.0",
-						"glob": "^7.1.2",
-						"lru-cache": "^4.1.3",
-						"make-fetch-happen": "^4.0.1",
-						"minimatch": "^3.0.4",
-						"minipass": "^2.3.3",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"normalize-package-data": "^2.4.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-packlist": "^1.1.10",
-						"npm-pick-manifest": "^2.1.0",
-						"osenv": "^0.1.5",
-						"promise-inflight": "^1.0.1",
-						"promise-retry": "^1.1.1",
-						"protoduck": "^5.0.0",
-						"rimraf": "^2.6.2",
-						"safe-buffer": "^5.1.2",
-						"semver": "^5.5.0",
-						"ssri": "^6.0.0",
-						"tar": "^4.4.3",
-						"unique-filename": "^1.1.0",
-						"which": "^1.3.0"
+						"bluebird": "3.5.1",
+						"cacache": "11.2.0",
+						"get-stream": "3.0.0",
+						"glob": "7.1.2",
+						"lru-cache": "4.1.3",
+						"make-fetch-happen": "4.0.1",
+						"minimatch": "3.0.4",
+						"minipass": "2.3.3",
+						"mississippi": "3.0.0",
+						"mkdirp": "0.5.1",
+						"normalize-package-data": "2.4.0",
+						"npm-package-arg": "6.1.0",
+						"npm-packlist": "1.1.11",
+						"npm-pick-manifest": "2.1.0",
+						"osenv": "0.1.5",
+						"promise-inflight": "1.0.1",
+						"promise-retry": "1.1.1",
+						"protoduck": "5.0.0",
+						"rimraf": "2.6.2",
+						"safe-buffer": "5.1.2",
+						"semver": "5.5.0",
+						"ssri": "6.0.0",
+						"tar": "4.4.6",
+						"unique-filename": "1.1.0",
+						"which": "1.3.1"
 					}
 				},
 				"parallel-transform": {
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"cyclist": "~0.2.2",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.1.5"
+						"cyclist": "0.2.2",
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"path-exists": {
@@ -6275,8 +6275,8 @@
 					"version": "1.1.1",
 					"bundled": true,
 					"requires": {
-						"err-code": "^1.0.0",
-						"retry": "^0.10.0"
+						"err-code": "1.1.2",
+						"retry": "0.10.1"
 					},
 					"dependencies": {
 						"retry": {
@@ -6289,7 +6289,7 @@
 					"version": "0.3.0",
 					"bundled": true,
 					"requires": {
-						"read": "1"
+						"read": "1.0.7"
 					}
 				},
 				"proto-list": {
@@ -6300,7 +6300,7 @@
 					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
-						"genfun": "^4.0.1"
+						"genfun": "4.0.1"
 					}
 				},
 				"prr": {
@@ -6319,25 +6319,25 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
 					}
 				},
 				"pumpify": {
 					"version": "1.5.1",
 					"bundled": true,
 					"requires": {
-						"duplexify": "^3.6.0",
-						"inherits": "^2.0.3",
-						"pump": "^2.0.0"
+						"duplexify": "3.6.0",
+						"inherits": "2.0.3",
+						"pump": "2.0.1"
 					},
 					"dependencies": {
 						"pump": {
 							"version": "2.0.1",
 							"bundled": true,
 							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
+								"end-of-stream": "1.4.1",
+								"once": "1.4.0"
 							}
 						}
 					}
@@ -6358,8 +6358,8 @@
 					"version": "6.1.0",
 					"bundled": true,
 					"requires": {
-						"decode-uri-component": "^0.2.0",
-						"strict-uri-encode": "^2.0.0"
+						"decode-uri-component": "0.2.0",
+						"strict-uri-encode": "2.0.0"
 					}
 				},
 				"qw": {
@@ -6370,10 +6370,10 @@
 					"version": "1.2.7",
 					"bundled": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -6386,113 +6386,113 @@
 					"version": "1.0.7",
 					"bundled": true,
 					"requires": {
-						"mute-stream": "~0.0.4"
+						"mute-stream": "0.0.7"
 					}
 				},
 				"read-cmd-shim": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.2"
+						"graceful-fs": "4.1.11"
 					}
 				},
 				"read-installed": {
 					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"graceful-fs": "^4.1.2",
-						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0",
-						"semver": "2 || 3 || 4 || 5",
-						"slide": "~1.1.3",
-						"util-extend": "^1.0.1"
+						"debuglog": "1.0.1",
+						"graceful-fs": "4.1.11",
+						"read-package-json": "2.0.13",
+						"readdir-scoped-modules": "1.0.2",
+						"semver": "5.5.0",
+						"slide": "1.1.6",
+						"util-extend": "1.0.3"
 					}
 				},
 				"read-package-json": {
 					"version": "2.0.13",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.1.1",
-						"graceful-fs": "^4.1.2",
-						"json-parse-better-errors": "^1.0.1",
-						"normalize-package-data": "^2.0.0",
-						"slash": "^1.0.0"
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"json-parse-better-errors": "1.0.2",
+						"normalize-package-data": "2.4.0",
+						"slash": "1.0.0"
 					}
 				},
 				"read-package-tree": {
 					"version": "5.2.1",
 					"bundled": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"dezalgo": "^1.0.0",
-						"once": "^1.3.0",
-						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0"
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"once": "1.4.0",
+						"read-package-json": "2.0.13",
+						"readdir-scoped-modules": "1.0.2"
 					}
 				},
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"readdir-scoped-modules": {
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"debuglog": "^1.0.1",
-						"dezalgo": "^1.0.0",
-						"graceful-fs": "^4.1.2",
-						"once": "^1.3.0"
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"graceful-fs": "4.1.11",
+						"once": "1.4.0"
 					}
 				},
 				"registry-auth-token": {
 					"version": "3.3.2",
 					"bundled": true,
 					"requires": {
-						"rc": "^1.1.6",
-						"safe-buffer": "^5.0.1"
+						"rc": "1.2.7",
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"registry-url": {
 					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
-						"rc": "^1.0.1"
+						"rc": "1.2.7"
 					}
 				},
 				"request": {
 					"version": "2.88.0",
 					"bundled": true,
 					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
+						"aws-sign2": "0.7.0",
+						"aws4": "1.8.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.6",
+						"extend": "3.0.2",
+						"forever-agent": "0.6.1",
+						"form-data": "2.3.2",
+						"har-validator": "5.1.0",
+						"http-signature": "1.2.0",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.19",
+						"oauth-sign": "0.9.0",
+						"performance-now": "2.1.0",
+						"qs": "6.5.2",
+						"safe-buffer": "5.1.2",
+						"tough-cookie": "2.4.3",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.3.2"
 					}
 				},
 				"require-directory": {
@@ -6515,14 +6515,14 @@
 					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"run-queue": {
 					"version": "1.0.3",
 					"bundled": true,
 					"requires": {
-						"aproba": "^1.1.1"
+						"aproba": "1.2.0"
 					}
 				},
 				"safe-buffer": {
@@ -6541,7 +6541,7 @@
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"semver": "^5.0.3"
+						"semver": "5.5.0"
 					}
 				},
 				"set-blocking": {
@@ -6552,15 +6552,15 @@
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"readable-stream": "^2.0.2"
+						"graceful-fs": "4.1.11",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"shebang-regex": "^1.0.0"
+						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -6587,16 +6587,16 @@
 					"version": "2.2.0",
 					"bundled": true,
 					"requires": {
-						"ip": "^1.1.5",
-						"smart-buffer": "^4.0.1"
+						"ip": "1.1.5",
+						"smart-buffer": "4.0.1"
 					}
 				},
 				"socks-proxy-agent": {
 					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
-						"agent-base": "~4.2.0",
-						"socks": "~2.2.0"
+						"agent-base": "4.2.0",
+						"socks": "2.2.0"
 					}
 				},
 				"sorted-object": {
@@ -6607,16 +6607,16 @@
 					"version": "2.1.3",
 					"bundled": true,
 					"requires": {
-						"from2": "^1.3.0",
-						"stream-iterate": "^1.1.0"
+						"from2": "1.3.0",
+						"stream-iterate": "1.2.0"
 					},
 					"dependencies": {
 						"from2": {
 							"version": "1.3.0",
 							"bundled": true,
 							"requires": {
-								"inherits": "~2.0.1",
-								"readable-stream": "~1.1.10"
+								"inherits": "2.0.3",
+								"readable-stream": "1.1.14"
 							}
 						},
 						"isarray": {
@@ -6627,10 +6627,10 @@
 							"version": "1.1.14",
 							"bundled": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.1",
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.3",
 								"isarray": "0.0.1",
-								"string_decoder": "~0.10.x"
+								"string_decoder": "0.10.31"
 							}
 						},
 						"string_decoder": {
@@ -6643,8 +6643,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -6655,8 +6655,8 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -6667,15 +6667,15 @@
 					"version": "1.14.2",
 					"bundled": true,
 					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jsbn": "~0.1.0",
-						"safer-buffer": "^2.0.2",
-						"tweetnacl": "~0.14.0"
+						"asn1": "0.2.4",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.2",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.2",
+						"getpass": "0.1.7",
+						"jsbn": "0.1.1",
+						"safer-buffer": "2.1.2",
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"ssri": {
@@ -6686,16 +6686,16 @@
 					"version": "1.2.2",
 					"bundled": true,
 					"requires": {
-						"end-of-stream": "^1.1.0",
-						"stream-shift": "^1.0.0"
+						"end-of-stream": "1.4.1",
+						"stream-shift": "1.0.0"
 					}
 				},
 				"stream-iterate": {
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"readable-stream": "^2.1.5",
-						"stream-shift": "^1.0.0"
+						"readable-stream": "2.3.6",
+						"stream-shift": "1.0.0"
 					}
 				},
 				"stream-shift": {
@@ -6710,8 +6710,8 @@
 					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -6726,7 +6726,7 @@
 							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -6735,7 +6735,7 @@
 					"version": "1.1.1",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"stringify-package": {
@@ -6746,7 +6746,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-eof": {
@@ -6761,20 +6761,20 @@
 					"version": "5.4.0",
 					"bundled": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				},
 				"tar": {
 					"version": "4.4.6",
 					"bundled": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.3",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.3.3",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.2",
+						"yallist": "3.0.2"
 					},
 					"dependencies": {
 						"yallist": {
@@ -6787,7 +6787,7 @@
 					"version": "1.2.0",
 					"bundled": true,
 					"requires": {
-						"execa": "^0.7.0"
+						"execa": "0.7.0"
 					}
 				},
 				"text-table": {
@@ -6802,8 +6802,8 @@
 					"version": "2.0.3",
 					"bundled": true,
 					"requires": {
-						"readable-stream": "^2.1.5",
-						"xtend": "~4.0.1"
+						"readable-stream": "2.3.6",
+						"xtend": "4.0.1"
 					}
 				},
 				"timed-out": {
@@ -6818,15 +6818,15 @@
 					"version": "2.4.3",
 					"bundled": true,
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
+						"psl": "1.1.29",
+						"punycode": "1.4.1"
 					}
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"tweetnacl": {
@@ -6850,21 +6850,21 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"unique-slug": "^2.0.0"
+						"unique-slug": "2.0.0"
 					}
 				},
 				"unique-slug": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"imurmurhash": "^0.1.4"
+						"imurmurhash": "0.1.4"
 					}
 				},
 				"unique-string": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"crypto-random-string": "^1.0.0"
+						"crypto-random-string": "1.0.0"
 					}
 				},
 				"unpipe": {
@@ -6879,23 +6879,23 @@
 					"version": "2.5.0",
 					"bundled": true,
 					"requires": {
-						"boxen": "^1.2.1",
-						"chalk": "^2.0.1",
-						"configstore": "^3.0.0",
-						"import-lazy": "^2.1.0",
-						"is-ci": "^1.0.10",
-						"is-installed-globally": "^0.1.0",
-						"is-npm": "^1.0.0",
-						"latest-version": "^3.0.0",
-						"semver-diff": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
+						"boxen": "1.3.0",
+						"chalk": "2.4.1",
+						"configstore": "3.1.2",
+						"import-lazy": "2.1.0",
+						"is-ci": "1.1.0",
+						"is-installed-globally": "0.1.0",
+						"is-npm": "1.0.0",
+						"latest-version": "3.1.0",
+						"semver-diff": "2.1.0",
+						"xdg-basedir": "3.0.0"
 					}
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"prepend-http": "^1.0.1"
+						"prepend-http": "1.0.4"
 					}
 				},
 				"util-deprecate": {
@@ -6914,38 +6914,38 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
 					}
 				},
 				"validate-npm-package-name": {
 					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"builtins": "^1.0.3"
+						"builtins": "1.0.3"
 					}
 				},
 				"verror": {
 					"version": "1.10.0",
 					"bundled": true,
 					"requires": {
-						"assert-plus": "^1.0.0",
+						"assert-plus": "1.0.0",
 						"core-util-is": "1.0.2",
-						"extsprintf": "^1.2.0"
+						"extsprintf": "1.3.0"
 					}
 				},
 				"wcwidth": {
 					"version": "1.0.1",
 					"bundled": true,
 					"requires": {
-						"defaults": "^1.0.3"
+						"defaults": "1.0.3"
 					}
 				},
 				"which": {
 					"version": "1.3.1",
 					"bundled": true,
 					"requires": {
-						"isexe": "^2.0.0"
+						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
@@ -6956,16 +6956,16 @@
 					"version": "1.1.2",
 					"bundled": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					},
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -6974,31 +6974,31 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "^2.1.1"
+						"string-width": "2.1.1"
 					}
 				},
 				"worker-farm": {
 					"version": "1.6.0",
 					"bundled": true,
 					"requires": {
-						"errno": "~0.1.7"
+						"errno": "0.1.7"
 					}
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -7011,9 +7011,9 @@
 					"version": "2.3.0",
 					"bundled": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"xdg-basedir": {
@@ -7036,18 +7036,18 @@
 					"version": "11.0.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					},
 					"dependencies": {
 						"y18n": {
@@ -7060,7 +7060,7 @@
 					"version": "9.0.2",
 					"bundled": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -7070,10 +7070,10 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
+				"are-we-there-yet": "1.1.5",
+				"console-control-strings": "1.1.0",
+				"gauge": "2.7.4",
+				"set-blocking": "2.0.0"
 			}
 		},
 		"num2fraction": {
@@ -7101,9 +7101,9 @@
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7111,7 +7111,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"kind-of": {
@@ -7119,7 +7119,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -7134,7 +7134,7 @@
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.pick": {
@@ -7142,7 +7142,7 @@
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"once": {
@@ -7150,7 +7150,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"optionator": {
@@ -7158,12 +7158,12 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			}
 		},
 		"os-browserify": {
@@ -7181,7 +7181,7 @@
 			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"lcid": "^1.0.0"
+				"lcid": "1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -7194,8 +7194,8 @@
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"p-limit": {
@@ -7203,7 +7203,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -7211,7 +7211,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.3.0"
 			}
 		},
 		"p-try": {
@@ -7229,11 +7229,11 @@
 			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
+				"asn1.js": "4.10.1",
+				"browserify-aes": "1.2.0",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.17"
 			}
 		},
 		"parse-json": {
@@ -7241,7 +7241,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.2"
 			}
 		},
 		"pascalcase": {
@@ -7279,9 +7279,9 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -7296,11 +7296,11 @@
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
 			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
 			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"performance-now": {
@@ -7323,7 +7323,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
@@ -7331,7 +7331,7 @@
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"posix-character-classes": {
@@ -7344,10 +7344,10 @@
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
 			"requires": {
-				"chalk": "^1.1.3",
-				"js-base64": "^2.1.9",
-				"source-map": "^0.5.6",
-				"supports-color": "^3.2.3"
+				"chalk": "1.1.3",
+				"js-base64": "2.4.9",
+				"source-map": "0.5.7",
+				"supports-color": "3.2.3"
 			}
 		},
 		"postcss-calc": {
@@ -7355,9 +7355,9 @@
 			"resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
 			"requires": {
-				"postcss": "^5.0.2",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-css-calc": "^1.2.6"
+				"postcss": "5.2.18",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-css-calc": "1.3.0"
 			}
 		},
 		"postcss-colormin": {
@@ -7365,9 +7365,9 @@
 			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
 			"requires": {
-				"colormin": "^1.0.5",
-				"postcss": "^5.0.13",
-				"postcss-value-parser": "^3.2.3"
+				"colormin": "1.1.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-convert-values": {
@@ -7375,8 +7375,75 @@
 			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
 			"requires": {
-				"postcss": "^5.0.11",
-				"postcss-value-parser": "^3.1.2"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-custom-properties": {
+			"version": "8.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz",
+			"integrity": "sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==",
+			"requires": {
+				"postcss": "7.0.16",
+				"postcss-values-parser": "2.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.3"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"requires": {
+								"has-flag": "3.0.0"
+							}
+						}
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"requires": {
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-discard-comments": {
@@ -7384,7 +7451,7 @@
 			"resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -7392,7 +7459,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-empty": {
@@ -7400,7 +7467,7 @@
 			"resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
 			"requires": {
-				"postcss": "^5.0.14"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-overridden": {
@@ -7408,7 +7475,7 @@
 			"resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
 			"requires": {
-				"postcss": "^5.0.16"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-discard-unused": {
@@ -7416,8 +7483,8 @@
 			"resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
 			"requires": {
-				"postcss": "^5.0.14",
-				"uniqs": "^2.0.0"
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-filter-plugins": {
@@ -7425,7 +7492,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
 			"integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-load-config": {
@@ -7433,10 +7500,10 @@
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
 			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
 			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0",
-				"postcss-load-options": "^1.2.0",
-				"postcss-load-plugins": "^2.3.0"
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1",
+				"postcss-load-options": "1.2.0",
+				"postcss-load-plugins": "2.3.0"
 			}
 		},
 		"postcss-load-options": {
@@ -7444,8 +7511,8 @@
 			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
 			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
 			"requires": {
-				"cosmiconfig": "^2.1.0",
-				"object-assign": "^4.1.0"
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
 			}
 		},
 		"postcss-load-plugins": {
@@ -7453,8 +7520,8 @@
 			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
 			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
 			"requires": {
-				"cosmiconfig": "^2.1.1",
-				"object-assign": "^4.1.0"
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
 			}
 		},
 		"postcss-loader": {
@@ -7462,10 +7529,10 @@
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
 			"integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"postcss": "^6.0.0",
-				"postcss-load-config": "^2.0.0",
-				"schema-utils": "^0.4.0"
+				"loader-utils": "1.1.0",
+				"postcss": "6.0.23",
+				"postcss-load-config": "2.0.0",
+				"schema-utils": "0.4.7"
 			},
 			"dependencies": {
 				"ajv": {
@@ -7473,10 +7540,10 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
 					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
 					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
+						"fast-deep-equal": "2.0.1",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.4.1",
+						"uri-js": "4.2.2"
 					}
 				},
 				"ajv-keywords": {
@@ -7489,7 +7556,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.3"
 					}
 				},
 				"chalk": {
@@ -7497,9 +7564,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"cosmiconfig": {
@@ -7507,10 +7574,10 @@
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
 					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
 					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.9.0",
-						"parse-json": "^4.0.0",
-						"require-from-string": "^2.0.1"
+						"is-directory": "0.3.1",
+						"js-yaml": "3.12.0",
+						"parse-json": "4.0.0",
+						"require-from-string": "2.0.2"
 					}
 				},
 				"esprima": {
@@ -7533,8 +7600,8 @@
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"argparse": "1.0.10",
+						"esprima": "4.0.1"
 					}
 				},
 				"json-schema-traverse": {
@@ -7547,8 +7614,8 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"postcss": {
@@ -7556,9 +7623,9 @@
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"postcss-load-config": {
@@ -7566,8 +7633,8 @@
 					"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
 					"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
 					"requires": {
-						"cosmiconfig": "^4.0.0",
-						"import-cwd": "^2.0.0"
+						"cosmiconfig": "4.0.0",
+						"import-cwd": "2.1.0"
 					}
 				},
 				"require-from-string": {
@@ -7580,8 +7647,8 @@
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
+						"ajv": "6.5.4",
+						"ajv-keywords": "3.2.0"
 					}
 				},
 				"source-map": {
@@ -7594,7 +7661,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7604,9 +7671,9 @@
 			"resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.10",
-				"postcss-value-parser": "^3.1.1"
+				"has": "1.0.3",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-merge-longhand": {
@@ -7614,7 +7681,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-merge-rules": {
@@ -7622,11 +7689,11 @@
 			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
 			"requires": {
-				"browserslist": "^1.5.2",
-				"caniuse-api": "^1.5.2",
-				"postcss": "^5.0.4",
-				"postcss-selector-parser": "^2.2.2",
-				"vendors": "^1.0.0"
+				"browserslist": "1.7.7",
+				"caniuse-api": "1.6.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3",
+				"vendors": "1.0.2"
 			}
 		},
 		"postcss-message-helpers": {
@@ -7639,9 +7706,9 @@
 			"resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
 			"requires": {
-				"object-assign": "^4.0.1",
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-minify-gradients": {
@@ -7649,8 +7716,8 @@
 			"resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
 			"requires": {
-				"postcss": "^5.0.12",
-				"postcss-value-parser": "^3.3.0"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-minify-params": {
@@ -7658,10 +7725,10 @@
 			"resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.2",
-				"postcss-value-parser": "^3.0.2",
-				"uniqs": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-minify-selectors": {
@@ -7669,10 +7736,10 @@
 			"resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
 			"requires": {
-				"alphanum-sort": "^1.0.2",
-				"has": "^1.0.1",
-				"postcss": "^5.0.14",
-				"postcss-selector-parser": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"has": "1.0.3",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3"
 			}
 		},
 		"postcss-modules-extract-imports": {
@@ -7680,7 +7747,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
 			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7688,7 +7755,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.3"
 					}
 				},
 				"chalk": {
@@ -7696,9 +7763,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"has-flag": {
@@ -7711,9 +7778,9 @@
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"source-map": {
@@ -7726,7 +7793,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7736,8 +7803,8 @@
 			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7745,7 +7812,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.3"
 					}
 				},
 				"chalk": {
@@ -7753,9 +7820,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"has-flag": {
@@ -7768,9 +7835,9 @@
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"source-map": {
@@ -7783,7 +7850,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7793,8 +7860,8 @@
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
 			"requires": {
-				"css-selector-tokenizer": "^0.7.0",
-				"postcss": "^6.0.1"
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7802,7 +7869,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.3"
 					}
 				},
 				"chalk": {
@@ -7810,9 +7877,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"has-flag": {
@@ -7825,9 +7892,9 @@
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"source-map": {
@@ -7840,7 +7907,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7850,8 +7917,8 @@
 			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
 			"requires": {
-				"icss-replace-symbols": "^1.1.0",
-				"postcss": "^6.0.1"
+				"icss-replace-symbols": "1.1.0",
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7859,7 +7926,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.3"
 					}
 				},
 				"chalk": {
@@ -7867,9 +7934,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
 					}
 				},
 				"has-flag": {
@@ -7882,9 +7949,9 @@
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"source-map": {
@@ -7897,7 +7964,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7907,7 +7974,7 @@
 			"resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
 			"requires": {
-				"postcss": "^5.0.5"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-normalize-url": {
@@ -7915,10 +7982,10 @@
 			"resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
 			"requires": {
-				"is-absolute-url": "^2.0.0",
-				"normalize-url": "^1.4.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3"
+				"is-absolute-url": "2.1.0",
+				"normalize-url": "1.9.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-ordered-values": {
@@ -7926,8 +7993,8 @@
 			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.1"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-reduce-idents": {
@@ -7935,8 +8002,8 @@
 			"resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
 			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-reduce-initial": {
@@ -7944,7 +8011,7 @@
 			"resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
 			"requires": {
-				"postcss": "^5.0.4"
+				"postcss": "5.2.18"
 			}
 		},
 		"postcss-reduce-transforms": {
@@ -7952,9 +8019,9 @@
 			"resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.8",
-				"postcss-value-parser": "^3.0.1"
+				"has": "1.0.3",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
 			}
 		},
 		"postcss-selector-parser": {
@@ -7962,9 +8029,9 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
 			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
 			}
 		},
 		"postcss-svgo": {
@@ -7972,10 +8039,10 @@
 			"resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
 			"requires": {
-				"is-svg": "^2.0.0",
-				"postcss": "^5.0.14",
-				"postcss-value-parser": "^3.2.3",
-				"svgo": "^0.7.0"
+				"is-svg": "2.1.0",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"svgo": "0.7.2"
 			}
 		},
 		"postcss-unique-selectors": {
@@ -7983,9 +8050,9 @@
 			"resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
 			"requires": {
-				"alphanum-sort": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
 			}
 		},
 		"postcss-value-parser": {
@@ -7993,14 +8060,24 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
 			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
 		},
+		"postcss-values-parser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+			"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
+			"requires": {
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
+			}
+		},
 		"postcss-zindex": {
 			"version": "2.2.0",
 			"resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
 			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
+				"has": "1.0.3",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
 			}
 		},
 		"prelude-ls": {
@@ -8043,12 +8120,12 @@
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
 			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"parse-asn1": "5.1.1",
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"punycode": {
@@ -8081,7 +8158,7 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"requires": {
-				"safe-buffer": "^5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"randomfill": {
@@ -8089,8 +8166,8 @@
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"raw-loader": {
@@ -8103,9 +8180,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
 			}
 		},
 		"read-pkg-up": {
@@ -8113,8 +8190,8 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -8122,8 +8199,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -8131,7 +8208,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -8141,13 +8218,13 @@
 			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -8155,9 +8232,9 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
+				"graceful-fs": "4.1.11",
+				"micromatch": "3.1.10",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"readline2": {
@@ -8165,8 +8242,8 @@
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
 			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
 				"mute-stream": "0.0.5"
 			},
 			"dependencies": {
@@ -8182,8 +8259,8 @@
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
 			}
 		},
 		"reduce-css-calc": {
@@ -8191,9 +8268,9 @@
 			"resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
+				"balanced-match": "0.4.2",
+				"math-expression-evaluator": "1.2.17",
+				"reduce-function-call": "1.0.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -8208,7 +8285,7 @@
 			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
 			"requires": {
-				"balanced-match": "^0.4.2"
+				"balanced-match": "0.4.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -8233,9 +8310,9 @@
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.8"
 			}
 		},
 		"regex-not": {
@@ -8243,8 +8320,8 @@
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regex-parser": {
@@ -8257,9 +8334,9 @@
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.4.0",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -8272,7 +8349,7 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -8287,8 +8364,8 @@
 			"resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
 			"integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
 			"requires": {
-				"argparse": "~0.1.15",
-				"autolinker": "~0.15.0"
+				"argparse": "0.1.16",
+				"autolinker": "0.15.3"
 			},
 			"dependencies": {
 				"argparse": {
@@ -8296,8 +8373,8 @@
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
 					"integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
 					"requires": {
-						"underscore": "~1.7.0",
-						"underscore.string": "~2.4.0"
+						"underscore": "1.7.0",
+						"underscore.string": "2.4.0"
 					}
 				}
 			}
@@ -8322,7 +8399,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"request": {
@@ -8330,26 +8407,26 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.8.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.7",
+				"extend": "3.0.2",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.20",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.3.2"
 			}
 		},
 		"require-directory": {
@@ -8372,8 +8449,8 @@
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -8398,15 +8475,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.3.1.tgz",
 			"integrity": "sha512-tpt4A/tOT8jxRDa91RbBV4c22AGj+WllOxT8rYSYhT2XDdL33Nca9HudwVx4mvP9PLokz+wpCu44tWUGVMYYLA==",
 			"requires": {
-				"adjust-sourcemap-loader": "^1.1.0",
-				"camelcase": "^4.1.0",
-				"convert-source-map": "^1.5.1",
-				"loader-utils": "^1.1.0",
-				"lodash.defaults": "^4.0.0",
-				"rework": "^1.0.1",
-				"rework-visit": "^1.0.0",
-				"source-map": "^0.5.7",
-				"urix": "^0.1.0"
+				"adjust-sourcemap-loader": "1.2.0",
+				"camelcase": "4.1.0",
+				"convert-source-map": "1.6.0",
+				"loader-utils": "1.1.0",
+				"lodash.defaults": "4.2.0",
+				"rework": "1.0.1",
+				"rework-visit": "1.0.0",
+				"source-map": "0.5.7",
+				"urix": "0.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -8426,8 +8503,8 @@
 			"resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
 			"integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
 			"requires": {
-				"convert-source-map": "^0.3.3",
-				"css": "^2.0.0"
+				"convert-source-map": "0.3.5",
+				"css": "2.2.4"
 			},
 			"dependencies": {
 				"convert-source-map": {
@@ -8447,7 +8524,7 @@
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"requires": {
-				"align-text": "^0.1.1"
+				"align-text": "0.1.4"
 			}
 		},
 		"rimraf": {
@@ -8455,7 +8532,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.3"
 			}
 		},
 		"ripemd160": {
@@ -8463,8 +8540,8 @@
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
 			}
 		},
 		"safe-buffer": {
@@ -8477,7 +8554,7 @@
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -8490,10 +8567,10 @@
 			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
 			"requires": {
-				"glob": "^7.0.0",
-				"lodash": "^4.0.0",
-				"scss-tokenizer": "^0.2.3",
-				"yargs": "^7.0.0"
+				"glob": "7.1.3",
+				"lodash": "4.17.11",
+				"scss-tokenizer": "0.2.3",
+				"yargs": "7.0.2"
 			}
 		},
 		"sass-lint": {
@@ -8501,20 +8578,20 @@
 			"resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.12.1.tgz",
 			"integrity": "sha1-Yw9pwhaqIGuCMvsqqQe98zNrbYM=",
 			"requires": {
-				"commander": "^2.8.1",
-				"eslint": "^2.7.0",
+				"commander": "2.19.0",
+				"eslint": "2.13.1",
 				"front-matter": "2.1.2",
-				"fs-extra": "^3.0.1",
-				"glob": "^7.0.0",
-				"globule": "^1.0.0",
-				"gonzales-pe-sl": "^4.2.3",
-				"js-yaml": "^3.5.4",
-				"known-css-properties": "^0.3.0",
-				"lodash.capitalize": "^4.1.0",
-				"lodash.kebabcase": "^4.0.0",
-				"merge": "^1.2.0",
-				"path-is-absolute": "^1.0.0",
-				"util": "^0.10.3"
+				"fs-extra": "3.0.1",
+				"glob": "7.1.3",
+				"globule": "1.2.1",
+				"gonzales-pe-sl": "4.2.3",
+				"js-yaml": "3.7.0",
+				"known-css-properties": "0.3.0",
+				"lodash.capitalize": "4.2.1",
+				"lodash.kebabcase": "4.1.1",
+				"merge": "1.2.1",
+				"path-is-absolute": "1.0.1",
+				"util": "0.10.3"
 			},
 			"dependencies": {
 				"ajv": {
@@ -8522,8 +8599,8 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
 					}
 				},
 				"ajv-keywords": {
@@ -8541,7 +8618,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"eslint": {
@@ -8549,39 +8626,39 @@
 					"resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
 					"integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
 					"requires": {
-						"chalk": "^1.1.3",
-						"concat-stream": "^1.4.6",
-						"debug": "^2.1.1",
-						"doctrine": "^1.2.2",
-						"es6-map": "^0.1.3",
-						"escope": "^3.6.0",
-						"espree": "^3.1.6",
-						"estraverse": "^4.2.0",
-						"esutils": "^2.0.2",
-						"file-entry-cache": "^1.1.1",
-						"glob": "^7.0.3",
-						"globals": "^9.2.0",
-						"ignore": "^3.1.2",
-						"imurmurhash": "^0.1.4",
-						"inquirer": "^0.12.0",
-						"is-my-json-valid": "^2.10.0",
-						"is-resolvable": "^1.0.0",
-						"js-yaml": "^3.5.1",
-						"json-stable-stringify": "^1.0.0",
-						"levn": "^0.3.0",
-						"lodash": "^4.0.0",
-						"mkdirp": "^0.5.0",
-						"optionator": "^0.8.1",
-						"path-is-absolute": "^1.0.0",
-						"path-is-inside": "^1.0.1",
-						"pluralize": "^1.2.1",
-						"progress": "^1.1.8",
-						"require-uncached": "^1.0.2",
-						"shelljs": "^0.6.0",
-						"strip-json-comments": "~1.0.1",
-						"table": "^3.7.8",
-						"text-table": "~0.2.0",
-						"user-home": "^2.0.0"
+						"chalk": "1.1.3",
+						"concat-stream": "1.6.2",
+						"debug": "2.6.9",
+						"doctrine": "1.2.3",
+						"es6-map": "0.1.5",
+						"escope": "3.6.0",
+						"espree": "3.5.4",
+						"estraverse": "4.2.0",
+						"esutils": "2.0.2",
+						"file-entry-cache": "1.3.1",
+						"glob": "7.1.3",
+						"globals": "9.18.0",
+						"ignore": "3.3.10",
+						"imurmurhash": "0.1.4",
+						"inquirer": "0.12.0",
+						"is-my-json-valid": "2.19.0",
+						"is-resolvable": "1.1.0",
+						"js-yaml": "3.7.0",
+						"json-stable-stringify": "1.0.1",
+						"levn": "0.3.0",
+						"lodash": "4.17.11",
+						"mkdirp": "0.5.1",
+						"optionator": "0.8.2",
+						"path-is-absolute": "1.0.1",
+						"path-is-inside": "1.0.2",
+						"pluralize": "1.2.1",
+						"progress": "1.1.8",
+						"require-uncached": "1.0.3",
+						"shelljs": "0.6.1",
+						"strip-json-comments": "1.0.4",
+						"table": "3.8.3",
+						"text-table": "0.2.0",
+						"user-home": "2.0.0"
 					}
 				},
 				"figures": {
@@ -8589,8 +8666,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"file-entry-cache": {
@@ -8598,8 +8675,8 @@
 					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
 					"integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
 					"requires": {
-						"flat-cache": "^1.2.1",
-						"object-assign": "^4.0.1"
+						"flat-cache": "1.3.0",
+						"object-assign": "4.1.1"
 					}
 				},
 				"globals": {
@@ -8612,19 +8689,19 @@
 					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 					"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
 					"requires": {
-						"ansi-escapes": "^1.1.0",
-						"ansi-regex": "^2.0.0",
-						"chalk": "^1.0.0",
-						"cli-cursor": "^1.0.1",
-						"cli-width": "^2.0.0",
-						"figures": "^1.3.5",
-						"lodash": "^4.3.0",
-						"readline2": "^1.0.1",
-						"run-async": "^0.1.0",
-						"rx-lite": "^3.1.2",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.0",
-						"through": "^2.3.6"
+						"ansi-escapes": "1.4.0",
+						"ansi-regex": "2.1.1",
+						"chalk": "1.1.3",
+						"cli-cursor": "1.0.2",
+						"cli-width": "2.2.0",
+						"figures": "1.7.0",
+						"lodash": "4.17.11",
+						"readline2": "1.0.1",
+						"run-async": "0.1.0",
+						"rx-lite": "3.1.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"through": "2.3.8"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -8652,8 +8729,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				},
 				"run-async": {
@@ -8661,7 +8738,7 @@
 					"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 					"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
 					"requires": {
-						"once": "^1.3.0"
+						"once": "1.4.0"
 					}
 				},
 				"rx-lite": {
@@ -8684,12 +8761,12 @@
 					"resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
 					"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
 					"requires": {
-						"ajv": "^4.7.0",
-						"ajv-keywords": "^1.0.0",
-						"chalk": "^1.1.1",
-						"lodash": "^4.0.0",
+						"ajv": "4.11.8",
+						"ajv-keywords": "1.5.1",
+						"chalk": "1.1.3",
+						"lodash": "4.17.11",
 						"slice-ansi": "0.0.4",
-						"string-width": "^2.0.0"
+						"string-width": "2.1.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -8702,8 +8779,8 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
+								"is-fullwidth-code-point": "2.0.0",
+								"strip-ansi": "4.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -8711,7 +8788,7 @@
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -8723,11 +8800,11 @@
 			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
 			"integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
 			"requires": {
-				"clone-deep": "^2.0.1",
-				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
-				"neo-async": "^2.5.0",
-				"pify": "^3.0.0"
+				"clone-deep": "2.0.2",
+				"loader-utils": "1.1.0",
+				"lodash.tail": "4.1.1",
+				"neo-async": "2.5.2",
+				"pify": "3.0.0"
 			}
 		},
 		"sax": {
@@ -8740,7 +8817,7 @@
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
 			"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
 			"requires": {
-				"ajv": "^5.0.0"
+				"ajv": "5.5.2"
 			}
 		},
 		"script-loader": {
@@ -8748,7 +8825,7 @@
 			"resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
 			"integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
 			"requires": {
-				"raw-loader": "~0.5.1"
+				"raw-loader": "0.5.1"
 			}
 		},
 		"scss-tokenizer": {
@@ -8756,8 +8833,8 @@
 			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
 			"requires": {
-				"js-base64": "^2.1.8",
-				"source-map": "^0.4.2"
+				"js-base64": "2.4.9",
+				"source-map": "0.4.4"
 			},
 			"dependencies": {
 				"source-map": {
@@ -8765,7 +8842,7 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -8785,10 +8862,10 @@
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8796,7 +8873,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -8811,8 +8888,8 @@
 			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"shallow-clone": {
@@ -8820,9 +8897,9 @@
 			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
 			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
 			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^5.0.0",
-				"mixin-object": "^2.0.1"
+				"is-extendable": "0.1.1",
+				"kind-of": "5.1.0",
+				"mixin-object": "2.0.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -8852,14 +8929,14 @@
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8867,7 +8944,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -8875,7 +8952,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -8885,9 +8962,9 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8895,7 +8972,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -8903,7 +8980,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -8911,7 +8988,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -8919,9 +8996,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -8931,7 +9008,7 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -8939,7 +9016,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -8949,7 +9026,7 @@
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"requires": {
-				"is-plain-obj": "^1.0.0"
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"source-list-map": {
@@ -8967,11 +9044,11 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.2",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -8979,7 +9056,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"requires": {
-				"source-map": "^0.5.6"
+				"source-map": "0.5.7"
 			}
 		},
 		"source-map-url": {
@@ -8992,8 +9069,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
 			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.1"
 			}
 		},
 		"spdx-exceptions": {
@@ -9006,8 +9083,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.2.0",
+				"spdx-license-ids": "3.0.1"
 			}
 		},
 		"spdx-license-ids": {
@@ -9020,7 +9097,7 @@
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -9033,15 +9110,15 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.4",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.2",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.2",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"static-extend": {
@@ -9049,8 +9126,8 @@
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -9058,7 +9135,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -9068,7 +9145,7 @@
 			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
 			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"stream-browserify": {
@@ -9076,8 +9153,8 @@
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"stream-http": {
@@ -9085,11 +9162,11 @@
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
 			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
 			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.6",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"string-width": {
@@ -9097,9 +9174,9 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"strip-ansi": "3.0.1"
 			}
 		},
 		"string_decoder": {
@@ -9107,7 +9184,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"strip-ansi": {
@@ -9115,7 +9192,7 @@
 			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -9123,7 +9200,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-indent": {
@@ -9131,7 +9208,7 @@
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"requires": {
-				"get-stdin": "^4.0.1"
+				"get-stdin": "4.0.1"
 			}
 		},
 		"supports-color": {
@@ -9139,7 +9216,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 			"requires": {
-				"has-flag": "^1.0.0"
+				"has-flag": "1.0.0"
 			}
 		},
 		"svgo": {
@@ -9147,13 +9224,13 @@
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
 			"requires": {
-				"coa": "~1.0.1",
-				"colors": "~1.1.2",
-				"csso": "~2.3.1",
-				"js-yaml": "~3.7.0",
-				"mkdirp": "~0.5.1",
-				"sax": "~1.2.1",
-				"whet.extend": "~0.9.9"
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.3.2",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
 			},
 			"dependencies": {
 				"colors": {
@@ -9183,7 +9260,7 @@
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"requires": {
-				"setimmediate": "^1.0.4"
+				"setimmediate": "1.0.5"
 			}
 		},
 		"to-arraybuffer": {
@@ -9201,7 +9278,7 @@
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -9209,7 +9286,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -9219,10 +9296,10 @@
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -9230,8 +9307,8 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"tough-cookie": {
@@ -9239,7 +9316,7 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			}
 		},
 		"trim-newlines": {
@@ -9257,7 +9334,7 @@
 			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
 			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
 			"requires": {
-				"glob": "^7.1.2"
+				"glob": "7.1.3"
 			}
 		},
 		"tty-browserify": {
@@ -9270,7 +9347,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -9284,7 +9361,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"typedarray": {
@@ -9297,9 +9374,9 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -9312,8 +9389,8 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
 						"wordwrap": "0.0.2"
 					}
 				},
@@ -9327,9 +9404,9 @@
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -9356,10 +9433,10 @@
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -9367,7 +9444,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -9375,10 +9452,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -9403,8 +9480,8 @@
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -9412,9 +9489,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -9444,7 +9521,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -9480,9 +9557,9 @@
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
 			"integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
 			"requires": {
-				"loader-utils": "^1.0.2",
-				"mime": "^1.4.1",
-				"schema-utils": "^0.3.0"
+				"loader-utils": "1.1.0",
+				"mime": "1.6.0",
+				"schema-utils": "0.3.0"
 			}
 		},
 		"use": {
@@ -9495,7 +9572,7 @@
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
 			"requires": {
-				"os-homedir": "^1.0.0"
+				"os-homedir": "1.0.2"
 			}
 		},
 		"util": {
@@ -9528,8 +9605,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.2",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"vendors": {
@@ -9542,9 +9619,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vm-browserify": {
@@ -9560,9 +9637,9 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"requires": {
-				"chokidar": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
+				"chokidar": "2.0.4",
+				"graceful-fs": "4.1.11",
+				"neo-async": "2.5.2"
 			}
 		},
 		"webpack": {
@@ -9570,27 +9647,27 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
 			"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
 			"requires": {
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^2.0.0",
-				"ajv": "^4.7.0",
-				"ajv-keywords": "^1.1.1",
-				"async": "^2.1.2",
-				"enhanced-resolve": "^3.3.0",
-				"interpret": "^1.0.0",
-				"json-loader": "^0.5.4",
-				"json5": "^0.5.1",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^0.2.16",
-				"memory-fs": "~0.4.1",
-				"mkdirp": "~0.5.0",
-				"node-libs-browser": "^2.0.0",
-				"source-map": "^0.5.3",
-				"supports-color": "^3.1.0",
-				"tapable": "~0.2.5",
-				"uglify-js": "^2.8.27",
-				"watchpack": "^1.3.1",
-				"webpack-sources": "^1.0.1",
-				"yargs": "^6.0.0"
+				"acorn": "5.7.3",
+				"acorn-dynamic-import": "2.0.2",
+				"ajv": "4.11.8",
+				"ajv-keywords": "1.5.1",
+				"async": "2.6.1",
+				"enhanced-resolve": "3.4.1",
+				"interpret": "1.1.0",
+				"json-loader": "0.5.7",
+				"json5": "0.5.1",
+				"loader-runner": "2.3.1",
+				"loader-utils": "0.2.17",
+				"memory-fs": "0.4.1",
+				"mkdirp": "0.5.1",
+				"node-libs-browser": "2.1.0",
+				"source-map": "0.5.7",
+				"supports-color": "3.2.3",
+				"tapable": "0.2.8",
+				"uglify-js": "2.8.29",
+				"watchpack": "1.6.0",
+				"webpack-sources": "1.3.0",
+				"yargs": "6.6.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -9598,8 +9675,8 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
 					}
 				},
 				"ajv-keywords": {
@@ -9612,10 +9689,10 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
 					}
 				},
 				"yargs": {
@@ -9623,19 +9700,19 @@
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.3",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
 					}
 				},
 				"yargs-parser": {
@@ -9643,7 +9720,7 @@
 					"resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "3.0.0"
 					}
 				}
 			}
@@ -9653,8 +9730,8 @@
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
 			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
+				"source-list-map": "2.0.1",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -9674,7 +9751,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -9687,7 +9764,7 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"requires": {
-				"string-width": "^1.0.2 || 2"
+				"string-width": "1.0.2"
 			}
 		},
 		"window-size": {
@@ -9705,8 +9782,8 @@
 			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			}
 		},
 		"wrappy": {
@@ -9719,7 +9796,7 @@
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"xtend": {
@@ -9737,19 +9814,19 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.0.2.tgz",
 			"integrity": "sha1-EVuX3xMhgj6Lhkjolox4JSEiH2c=",
 			"requires": {
-				"camelcase": "^3.0.0",
-				"cliui": "^3.2.0",
-				"decamelize": "^1.1.1",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^1.4.0",
-				"read-pkg-up": "^1.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^1.0.2",
-				"which-module": "^1.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^5.0.0"
+				"camelcase": "3.0.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.3",
+				"os-locale": "1.4.0",
+				"read-pkg-up": "1.0.1",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "1.0.2",
+				"which-module": "1.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "5.0.0"
 			}
 		},
 		"yargs-parser": {
@@ -9757,7 +9834,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 			"requires": {
-				"camelcase": "^3.0.0"
+				"camelcase": "3.0.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"modernizr-loader": "^1.0.1",
 		"node-sass": "^4.5.3",
 		"npm": "^6.0.0",
+		"postcss-custom-properties": "^8.0.10",
 		"postcss-load-config": "^1.2.0",
 		"postcss-loader": "^2.0.5",
 		"resolve-url-loader": "^2.0.2",


### PR DESCRIPTION
This PR bakes the `postcss-custom-properties` plugin into the CSS pipeline, allowing us to use CSS Variables with an automatic fallback to static properties based on their initial value. For example:

```css
:root {
  --color-section-background: red;
}

.section {
  background-color: var(--color-section-background);
}
```

Will produce:

```css
:root {
  --color-section-background: red;
}

.section {
  background-color: red;
  background-color: var(--color-section-background);
}
```

This will allow us to incrementally adopt CSS Variables (which are incredibly useful for a range of reasons) without immediately breaking support for older browsers, or manually patching in the fallbacks ourselves (which would require removal by hand when we drop support for said older browsers).

I recognise that we don't want to get into the habit of bloating the base configuration too much, so I can prepare an alternative PR that simply adds a parameter for applying extra plugins to the PostCSS loader configuration, but I'd like to see CSS Variables adopted across core, so I thought I'd start with this.