### PR TITLE
Add bundle analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 package-lock.json
+.idea
+yarn.lock

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 /**
  * Exports the settings for plugins in webpack.config
@@ -28,5 +29,6 @@ module.exports = (ENV) => {
     }),
     new webpack.NamedModulesPlugin(),
     uglifyPlugin,
+    process.env.ANALYZE_BUNDLE && new BundleAnalyzerPlugin()
   ].filter(plugin => plugin);
 };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
 		"sass-loader": "^6.0.5",
 		"script-loader": "^0.7.0",
 		"url-loader": "^0.6.2",
-		"webpack": "^2.6.1"
+		"webpack": "^2.6.1",
+		"webpack-bundle-analyzer": "^3.6.0"
 	},
 	"resolutions": {
 		"eslint": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@silverstripe/webpack-config",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "SilverStripe config files for modules",
 	"engines": {
 		"node": "^10.x"


### PR DESCRIPTION
Add a bundle analyzer to our webpack-config. That way you can define the following flag when building your bundle: `ANALYZE_BUNDLE=1 yarn build`

This will allow you to visualise what's in the bundle.
![image](https://user-images.githubusercontent.com/1168676/68093944-2063b900-ff00-11e9-98a7-b10fbc3a10c2.png)

# Parent issue
* https://github.com/silverstripe/silverstripe-admin/issues/987
