### PR TITLE
BUG Add ability to pass some options to the BundleAnalyzerPLugin so concurrent build of bundle can work

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -29,6 +29,6 @@ module.exports = (ENV) => {
     }),
     new webpack.NamedModulesPlugin(),
     uglifyPlugin,
-    process.env.ANALYZE_BUNDLE && new BundleAnalyzerPlugin()
+    process.env.ANALYZE_BUNDLE && new BundleAnalyzerPlugin({analyzerPort: 'auto'})
   ].filter(plugin => plugin);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@silverstripe/webpack-config",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "SilverStripe config files for modules",
 	"engines": {
 		"node": "^10.x"


### PR DESCRIPTION
Just realise the bundle analyser doesn't work on module that output multiple bundle because it tries to start a new server for each bundle.

This fix allows us to pass extra option to each bundle entry so we can do things like provide each entry a different port.