### PR TITLE
FIX Rename 'url' to 'node-url' to resolve browser API conflict

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -26,7 +26,7 @@ module.exports = () => ({
   'redux-thunk': 'ReduxThunk',
   redux: 'Redux',
   config: 'Config',
-  url: 'url',
+  url: 'NodeUrl',
   qs: 'qs',
   moment: 'moment',
   modernizr: 'modernizr',


### PR DESCRIPTION
Browsers already have a `URL` key on their `window` object, so this clashes with the expose-loader entry and makes it unusable.

Pairs with an adjustment to the expose-loader entry in `silverstripe/admin`: silverstripe/silverstripe-admin#1019