### PR TITLE
NEW Add GitHub Action for publishing to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+      - run: yarn install
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -103,3 +103,13 @@ const config = {
   ),
 }
 ```
+
+## Release process
+
+This package will be automatically published to NPM when the following steps are taken:
+
+1. The `version` key in `package.json` is updated on `master`
+2. A new release is created in GitHub from `master`
+
+Ensure you set the new version appropriately (considering Semver) and consistently between the `version` key and the release.
+


### PR DESCRIPTION
This will trigger a publish of the module whenever we create a new release, saving time for the few developers with access to the `@silverstripe` NPM org.

~Requires a `YARN_TOKEN` secret to be added to the repository.~ (added)