### PR TITLE
FIX Add a querystring hash to fonts

### DIFF
--- a/css/modules.js
+++ b/css/modules.js
@@ -119,7 +119,7 @@ module.exports = (ENV, { FILES_PATH, SRC, ROOT }, { useStyle } = {}) => {
         test: /fonts[\/\\]([\w_-]+)\.(woff2?|eot|ttf|svg)$/,
         loader: 'file-loader',
         options: {
-          name: 'fonts/[name].[ext]',
+          name: 'fonts/[name].[ext]?h=[contenthash]',
         },
       },
     ],


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/issues/1064

https://www.npmjs.com/package/file-loader#options

**`admin/client/src/styles/_fonts.scss`**

![image](https://user-images.githubusercontent.com/4809037/88134673-56390100-cc39-11ea-8f36-dedd871c8cfe.png)

**`admin/client/dist/styles/bundle.css`**

**Before**
![image](https://user-images.githubusercontent.com/4809037/88134602-2d187080-cc39-11ea-98eb-afb961e46993.png)

**After**
![image](https://user-images.githubusercontent.com/4809037/88134619-34d81500-cc39-11ea-8f26-5823b1810729.png)
