### PR TITLE
Register Toast actions

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -71,6 +71,7 @@ module.exports = () => ({
   'containers/InsertLinkModal/fileSchemaModalHandler': 'FileSchemaModalHandler',
   'state/breadcrumbs/BreadcrumbsActions': 'BreadcrumbsActions',
   'state/schema/SchemaActions': 'SchemaActions',
+  'state/toasts/ToastsActions': 'ToastsActions',
   'state/records/RecordsActions': 'RecordsActions',
   'state/records/RecordsActionTypes': 'RecordsActionTypes',
   'state/tabs/TabsActions': 'TabsActions',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@silverstripe/webpack-config",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "SilverStripe config files for modules",
 	"engines": {
 		"node": "^10.x"


### PR DESCRIPTION
We are introducing a new Toast in React API. This PR expose the action that will allow all module to trigger new toasts.

# Parent issue
* https://github.com/silverstripe/silverstripe-admin/issues/504

# Related PR
* https://github.com/silverstripe/silverstripe-asset-admin/pull/1111
* https://github.com/silverstripe/silverstripe-admin/issues/1068

Resolves silverstripe/silverstripe-admin#504