### PR TITLE
FIX Fix devtool error and remove comments in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ module.exports = [
       path: PATHS.DIST,
       filename: 'js/[name].js',
     },
-    devtool: (ENV !== 'production') ? 'source-map' : '',
+    devtool: (ENV !== 'production') ? 'source-map' : false,
     resolve: resolveJS(ENV, PATHS),
     externals: externalJS(ENV, PATHS),
     module: moduleJS(ENV, PATHS),
@@ -228,7 +228,7 @@ module.exports = [
     output: {
       path: PATHS.DIST,
     },
-    devtool: (ENV !== 'production') ? 'source-map' : '',
+    devtool: (ENV !== 'production') ? 'source-map' : false,
     module: moduleCSS(ENV, PATHS),
     // Pass the filename here, which will get passed down to MiniCssExtractPlugin
     plugins: pluginCSS(ENV, PATHS, 'css/[name].css'),

--- a/configMeta/baseWebpackConfig.js
+++ b/configMeta/baseWebpackConfig.js
@@ -53,19 +53,21 @@ module.exports = class BaseWebpackConfig {
 
     this.#vendorChunk = vendorChunk;
 
-    this.#config.optimization = {
-      splitChunks: {
-        cacheGroups: {
-          vendor: {
-            name: vendorChunk,
-            test: test,
-            reuseExistingChunk: true,
-            enforce: true,
-            chunks: 'all',
+    this.mergeConfig({
+      optimization: {
+        splitChunks: {
+          cacheGroups: {
+            vendor: {
+              name: vendorChunk,
+              test: test,
+              reuseExistingChunk: true,
+              enforce: true,
+              chunks: 'all',
+            }
           }
         }
       }
-    };
+    });
 
     // ensure entries are configured to "depend on" the vendor entry if necessary
     this.#splitVendorFromEntries();

--- a/configMeta/cssWebpackConfig.js
+++ b/configMeta/cssWebpackConfig.js
@@ -19,7 +19,7 @@ module.exports = class CssWebpackConfig extends BaseWebpackConfig {
       output: {
         path: PATHS.DIST,
       },
-      devtool: (ENV !== 'production') ? 'source-map' : '',
+      devtool: (ENV !== 'production') ? 'source-map' : false,
       module: moduleCSS(ENV, PATHS),
       plugins: pluginCSS(ENV, PATHS, filename),
     });

--- a/configMeta/javascriptWebpackConfig.js
+++ b/configMeta/javascriptWebpackConfig.js
@@ -19,7 +19,7 @@ module.exports = class JavascriptWebpackConfig extends BaseWebpackConfig {
         path: PATHS.DIST,
         filename: 'js/[name].js',
       },
-      devtool: (ENV !== 'production') ? 'source-map' : '',
+      devtool: (ENV !== 'production') ? 'source-map' : false,
       resolve: resolveJS(ENV, PATHS),
       module: moduleJS(ENV, PATHS),
       externals: externalJS(ENV, PATHS, moduleName),

--- a/configMeta/javascriptWebpackConfig.js
+++ b/configMeta/javascriptWebpackConfig.js
@@ -3,6 +3,7 @@ const externalJS = require('../js/externals');
 const moduleJS = require('../js/modules');
 const pluginJS = require('../js/plugins');
 const resolveJS = require('../js/resolve');
+const TerserPlugin = require('terser-webpack-plugin');
 
 /**
  * Dynamically generates webpack config for transpiling javascript using Silverstripe default settings
@@ -24,6 +25,19 @@ module.exports = class JavascriptWebpackConfig extends BaseWebpackConfig {
       module: moduleJS(ENV, PATHS),
       externals: externalJS(ENV, PATHS, moduleName),
       plugins: pluginJS(ENV),
+      optimization: {
+        minimize: true,
+        minimizer: [
+          new TerserPlugin({
+            extractComments: false,
+            terserOptions: {
+              format: {
+                comments: false,
+              },
+            },
+          }),
+        ],
+      },
     });
   }
 }


### PR DESCRIPTION
Webpack complains and won't build in production mode because `devtool` is set to an empty string (which used to be acceptable). This has to be `false` now.

docs: https://webpack.js.org/configuration/devtool/

I've also re-removed comments, which were being included by default against my expectations.
Having no comments is the behaviour for the CMS 4 version, so this just fixes a regression where that wasn't happening.

## NOTE
After this is merged, I need to create a new `2.0.0-alpha2` tag, re-release on npm, and run `yarn install` on all the related PRs so they're all using this new tag.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1312