### PR TITLE
ENH Expose @apollo/client and the new EmotionCssCacheProvider

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -54,6 +54,7 @@ module.exports = (ENV, PATHS, module) => {
       'components/TreeDropdownField/TreeDropdownFieldNode': 'TreeDropdownFieldNode',
       'components/VersionedBadge/VersionedBadge': 'VersionedBadge',
       'components/ViewModeToggle/ViewModeToggle': 'ViewModeToggle',
+      'containers/EmotionCssCacheProvider/EmotionCssCacheProvider': 'EmotionCssCacheProvider',
       'containers/FormBuilderLoader/FormBuilderLoader': 'FormBuilderLoader',
       'containers/InsertLinkModal/InsertLinkModal': 'InsertLinkModal',
       'containers/InsertLinkModal/fileSchemaModalHandler': 'FileSchemaModalHandler',
@@ -84,8 +85,7 @@ module.exports = (ENV, PATHS, module) => {
       // bundles/bundle.js aliases
       config: 'Config', // alias for lib/Config
       // bundles/vendor.js
-      // @apollo/client can't be exposed - see https://github.com/webpack-contrib/expose-loader/issues/188
-      // '@apollo/client': 'ApolloClient',
+      '@apollo/client': 'ApolloClient',
       classnames: 'classnames',
       'deep-freeze-strict': 'DeepFreezeStrict',
       'graphql-fragments': 'GraphQLFragments',


### PR DESCRIPTION
Add the libs now exposed via https://github.com/silverstripe/silverstripe-admin/pull/1432 to the externals array

## Note
After this is merged, it needs to be tagged as `2.0.0-alpha4` and a new release made in npm

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/655