### PR TITLE
FIX Revert removing sass-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 		"postcss-loader": "^7.0.1",
 		"resolve-url-loader": "^5.0.0",
 		"sass": "^1.55.0",
+		"sass-lint": "^1.13.1",
 		"sass-loader": "^13.1.0",
-		"stylelint": "^14.14.0",
 		"webpack": "^5.74.0",
 		"webpack-bundle-analyzer": "^4.7.0"
 	},


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1411

Note - sass-lint is abandoned however it still is functional. I've raised a [card](https://github.com/silverstripe/silverstripe-admin/issues/1437) to properly upgrade it to stylelint