### PR TITLE
ENH Expose lib/urls from silverstripe/admin

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -71,6 +71,7 @@ module.exports = (ENV, PATHS, module) => {
       'lib/ShortcodeSerialiser': 'ShortcodeSerialiser',
       'lib/SilverStripeComponent': 'SilverStripeComponent',
       'lib/TinyMCEActionRegistrar': 'TinyMCEActionRegistrar',
+      'lib/urls': 'ssUrlLib',
       'lib/withDragDropContext': 'withDragDropContext',
       'lib/withRouter': 'withRouter',
       'state/breadcrumbs/BreadcrumbsActions': 'BreadcrumbsActions',


### PR DESCRIPTION
Exposes a new lib which was added in https://github.com/silverstripe/silverstripe-admin/pull/1438
This is useful for joining URL paths together without caring if they have trailing/leading slashes, if there's a host already, etc.

## NOTE
Once merged, this needs to be tagged as a new alpha and released on NPM, then any PRs which require this need to be updated with `yarn upgrade @silverstripe/webpack-config`.

## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2780