### PR TITLE
ENH Expose sublibraries for some externals

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -86,6 +86,7 @@ module.exports = (ENV, PATHS, module) => {
       config: 'Config', // alias for lib/Config
       // bundles/vendor.js
       '@apollo/client': 'ApolloClient',
+      '@apollo/client/react/hoc': 'ApolloClientReactHoc',
       classnames: 'classnames',
       'deep-freeze-strict': 'DeepFreezeStrict',
       'graphql-fragments': 'GraphQLFragments',
@@ -102,9 +103,13 @@ module.exports = (ENV, PATHS, module) => {
       'react-dnd': 'ReactDND',
       'react-dnd-html5-backend': 'ReactDNDHtml5Backend',
       'react-dom': 'ReactDom',
+      'react-dom/client': 'ReactDomClient',
       'react-redux': 'ReactRedux',
       'react-router-dom': 'ReactRouterDom',
       'react-select': 'ReactSelect',
+      'react-select/async': 'ReactSelectAsync',
+      'react-select/async-creatable': 'ReactSelectAsyncCreatable',
+      'react-select/creatable': 'ReactSelectCreatable',
       reactstrap: 'Reactstrap',
       redux: 'Redux',
       'redux-form': 'ReduxForm',


### PR DESCRIPTION
Provides externals config for newly exposed sublibraries from https://github.com/silverstripe/silverstripe-admin/pull/1446

## Note
Once this PR is merged, this library needs to be tagged and given a new alpha release.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/644