### PR TITLE
MNT Replace sass-lint with stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 		"postcss-loader": "^7.0.1",
 		"resolve-url-loader": "^5.0.0",
 		"sass": "^1.55.0",
-		"sass-lint": "^1.13.1",
 		"sass-loader": "^13.1.0",
 		"webpack": "^5.74.0",
 		"webpack-bundle-analyzer": "^4.7.0"


### PR DESCRIPTION
## Description
Old unsupported `sass-lint` module was removed and replaced with `stylelint`. All required supported modules were added. 
## Issues
- https://github.com/silverstripe/webpack-config/issues/69