### PR TITLE
NEW Add UnsavedChangesIndicator components to externals

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -57,6 +57,8 @@ module.exports = (ENV, PATHS, module) => {
       'components/TreeDropdownField/TreeDropdownField': 'TreeDropdownField',
       'components/TreeDropdownField/TreeDropdownFieldMenu': 'TreeDropdownFieldMenu',
       'components/TreeDropdownField/TreeDropdownFieldNode': 'TreeDropdownFieldNode',
+      'components/UnsavedChangesIndicator/UnsavedChangesIndicator': 'UnsavedChangesIndicator',
+      'components/UnsavedChangesIndicator/UnsavedChangesIndicatorTimer': 'UnsavedChangesIndicatorTimer',
       'components/VersionedBadge/VersionedBadge': 'VersionedBadge',
       'components/ViewModeToggle/ViewModeToggle': 'ViewModeToggle',
       'containers/EmotionCssCacheProvider/EmotionCssCacheProvider': 'EmotionCssCacheProvider',


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1973

Not actually needed for these PRs, though we should still update webpack-config

Tag on npmjs as 3.2.0 after merging PR