### PR TITLE
FIX Use correct path for InputField

### DIFF
--- a/js/externals.js
+++ b/js/externals.js
@@ -51,7 +51,7 @@ module.exports = (ENV, PATHS, module) => {
       'components/Tag/CompactTagList': 'CompactTagList',
       'components/Tag/Tag': 'Tag',
       'components/Tag/TagList': 'TagList',
-      'components/TextField/InputField': 'InputField',
+      'components/InputField/InputField': 'InputField',
       'components/TextField/TextField': 'TextField',
       'legacy/ReactComponents/LegacyInputField': 'LegacyInputField',
       'legacy/ReactComponents/LegacyDateField': 'LegacyDateField',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@silverstripe/webpack-config",
-	"version": "3.1.0",
+	"version": "3.2.1",
 	"description": "SilverStripe config files for modules",
 	"engines": {
 		"node": ">=18.x"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/2119

Have already published 3.2.0 on npmjs - https://www.npmjs.com/package/@silverstripe/webpack-config - however it has the wrong path for InputField

Run `npm publish` after merge - UPDATE - DONE - [3.2.1](https://www.npmjs.com/package/@silverstripe/webpack-config) 