### PR TITLE
DEP Cap node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
 		"postcss-load-config": "^4.0.1",
 		"postcss-loader": "^7.0.1",
 		"resolve-url-loader": "^5.0.0",
-		"sass": "^1.55.0",
+		"sass": ">=1.55.0 <1.100.0",
 		"sass-loader": "^13.1.0",
+		"terser-webpack-plugin": "^5.3.16",
 		"webpack": "^5.74.0",
 		"webpack-bundle-analyzer": "^4.7.0"
 	},


### PR DESCRIPTION
Issue https://github.com/silverstripe/webpack-config/issues/95

node-sass dropped node-18 support (which Silverstripe still uses) in version 1.100.0, so need to install versions older than that

terser-webpack-plugin is also added because:
- The webpack-config package uses the terser-webpack-plugin package.
- But the webpack-config package does not list terser-webpack-plugin in its dependencies.
- Before version 5.108, webpack gave terser-webpack-plugin to webpack-config.
- Webpack 5.108 does not give terser-webpack-plugin.

So we're adding terser-webpack-plugin to the dependencies of webpack-config.

Assign to Steve after merge - need to:
a) publish on npmjs as 3.3.0
b) release on github as 3.3.0